### PR TITLE
Adding code to create BackendServices

### DIFF
--- a/app/mci/pkg/gcp/backendservice/backendservicesyncer.go
+++ b/app/mci/pkg/gcp/backendservice/backendservicesyncer.go
@@ -1,0 +1,136 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backendservice
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/hashicorp/go-multierror"
+	"google.golang.org/api/compute/v1"
+	ingressbe "k8s.io/ingress-gce/pkg/backends"
+
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/mci/pkg/gcp/healthcheck"
+	utilsnamer "github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/mci/pkg/gcp/namer"
+)
+
+type BackendServiceSyncer struct {
+	namer *utilsnamer.Namer
+	// Backend services provider to call GCP APIs to manipulate backend services.
+	bsp ingressbe.BackendServices
+}
+
+func NewBackendServiceSyncer(namer *utilsnamer.Namer, bsp ingressbe.BackendServices) BackendServiceSyncerInterface {
+	return &BackendServiceSyncer{
+		namer: namer,
+		bsp:   bsp,
+	}
+}
+
+// Ensure this implements BackendServiceSyncerInterface.
+var _ BackendServiceSyncerInterface = &BackendServiceSyncer{}
+
+// EnsureBackendService ensures that the required backend services exist for the given ports.
+// Does nothing if it exists already, else creates a new one.
+func (b *BackendServiceSyncer) EnsureBackendService(lbName string, ports []ingressbe.ServicePort, hcMap healthcheck.HealthChecksMap, npMap NamedPortsMap, igLinks []string) error {
+	fmt.Println("Ensuring backend services")
+	glog.V(5).Infof("Received health checks map: %v", hcMap)
+	glog.V(5).Infof("Received named ports map: %v", npMap)
+	glog.V(5).Infof("Received instance groups: %v", igLinks)
+	var err error
+	for _, p := range ports {
+		if beErr := b.ensureBackendService(lbName, p, hcMap[p.Port], npMap[p.Port], igLinks); beErr != nil {
+			beErr = fmt.Errorf("Error %s in ensuring backend service for port %v", beErr, p)
+			// Try ensuring backend services for all ports and return all errors at once.
+			err = multierror.Append(err, beErr)
+		}
+	}
+	return err
+}
+
+// ensureBackendService ensures that the required backend service exists for the given port.
+// Does nothing if it exists already, else creates a new one.
+func (b *BackendServiceSyncer) ensureBackendService(lbName string, port ingressbe.ServicePort, hc *compute.HealthCheck, np *compute.NamedPort, igLinks []string) error {
+	fmt.Println("Ensuring backend service for port:", port)
+	if hc == nil {
+		return fmt.Errorf("missing health check probably due to an error in creating health check. Cannot create backend service without health chech link")
+	}
+	if hc.SelfLink == "" {
+		glog.V(2).Infof("Unexpected: empty self link in hc: %v", hc)
+		return fmt.Errorf("missing self link in health check %s", hc.Name)
+	}
+	if np == nil {
+		return fmt.Errorf("missing corresponding named port on the instance group")
+	}
+	desiredBE := b.desiredBackendService(lbName, port, hc.SelfLink, np.Name, igLinks)
+	name := desiredBE.Name
+	// Check if backend service already exists.
+	existingBE, err := b.bsp.GetGlobalBackendService(name)
+	if err == nil {
+		fmt.Println("Backend service", name, "exists already. Checking if it matches our desired backend service")
+		glog.V(5).Infof("Existing backend service: %v\n, desired backend service: %v", existingBE, *desiredBE)
+		// Backend service with that name exists already. Check if it matches what we want.
+		if backendServiceMatches(desiredBE, existingBE) {
+			// Nothing to do. Desired backend service exists already.
+			fmt.Println("Desired backend service exists already")
+			return nil
+		}
+		// TODO (nikhiljindal): Require explicit permission from user before doing this.
+		fmt.Println("Updating existing backend service", name, "to match the desired state")
+		return b.bsp.UpdateGlobalBackendService(desiredBE)
+	}
+	glog.V(5).Infof("Got error %s while trying to get existing backend service %s", err, name)
+	// TODO(nikhiljindal): Handle non NotFound errors. We should create only if the error is NotFound.
+	// Create the backend service.
+	fmt.Println("Creating backend service", name)
+	glog.V(5).Infof("Creating backend service %v", *desiredBE)
+	return b.bsp.CreateGlobalBackendService(desiredBE)
+}
+
+func backendServiceMatches(desiredBE, existingBE *compute.BackendService) bool {
+	// TODO(nikhiljindal): Add proper logic to figure out if the 2 backend services match.
+	// Need to add the --force flag for user to consent overritting before this method can be updated to return false.
+	return true
+}
+
+func (b *BackendServiceSyncer) desiredBackendService(lbName string, port ingressbe.ServicePort, hcLink, portName string, igLinks []string) *compute.BackendService {
+	// Compute the desired backend service.
+	return &compute.BackendService{
+		Name:         b.namer.BeServiceName(port.Port),
+		Description:  fmt.Sprintf("Backend service for service %s as part of kubernetes multicluster loadbalancer %s", port.Description(), lbName),
+		Protocol:     string(port.Protocol),
+		HealthChecks: []string{hcLink},
+		Port:         port.Port,
+		PortName:     portName,
+		Backends:     desiredBackends(igLinks),
+	}
+}
+
+func desiredBackends(igLinks []string) []*compute.Backend {
+	var backends []*compute.Backend
+	for _, ig := range igLinks {
+		backends = append(backends, &compute.Backend{
+			Group: ig,
+			// We create the backend service with RATE balancing mode and set max rate
+			// per instance to max value so that all requests in a region are sent to
+			// instances in that region.
+			// Setting rps to 1, for example, would round robin requests amongst all
+			// instances.
+			BalancingMode:      "RATE",
+			MaxRatePerInstance: 1e14,
+		})
+	}
+	return backends
+}

--- a/app/mci/pkg/gcp/backendservice/backendservicesyncer_test.go
+++ b/app/mci/pkg/gcp/backendservice/backendservicesyncer_test.go
@@ -1,0 +1,75 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backendservice
+
+import (
+	"testing"
+
+	"google.golang.org/api/compute/v1"
+	ingressbe "k8s.io/ingress-gce/pkg/backends"
+
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/mci/pkg/gcp/healthcheck"
+	utilsnamer "github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/mci/pkg/gcp/namer"
+)
+
+func TestEnsureBackendService(t *testing.T) {
+	lbName := "lb-name"
+	port := int64(32211)
+	portName := "portName"
+	igLink := "igLink"
+	hcLink := "hcLink"
+	// Should create the backend service as expected.
+	bsp := ingressbe.NewFakeBackendServices(func(op int, be *compute.BackendService) error { return nil })
+	namer := utilsnamer.NewNamer("mci", lbName)
+	beName := namer.BeServiceName(port)
+	bss := NewBackendServiceSyncer(namer, bsp)
+	// GET should return NotFound.
+	if _, err := bsp.GetGlobalBackendService(beName); err == nil {
+		t.Fatalf("expected NotFound error, actual: nil")
+	}
+	err := bss.EnsureBackendService(lbName, []ingressbe.ServicePort{
+		{
+			Port:     port,
+			Protocol: "HTTP",
+		},
+	}, healthcheck.HealthChecksMap{
+		port: &compute.HealthCheck{
+			SelfLink: hcLink,
+		},
+	}, NamedPortsMap{
+		port: &compute.NamedPort{
+			Port: port,
+			Name: portName,
+		},
+	}, []string{igLink})
+	if err != nil {
+		t.Fatalf("expected no error in ensuring backend service, actual: %v", err)
+	}
+	// Verify that the created backend service is as expected.
+	be, err := bsp.GetGlobalBackendService(beName)
+	if err != nil {
+		t.Fatalf("expected nil error, actual: %v", err)
+	}
+	if len(be.HealthChecks) != 1 || be.HealthChecks[0] != hcLink {
+		t.Errorf("unexpected health check in backend service. expected: %s, got: %v", hcLink, be.HealthChecks)
+	}
+	if be.Port != port || be.PortName != portName {
+		t.Errorf("unexpected port and port name, expected: %s/%s, got: %s/%s", portName, port, be.PortName, be.Port)
+	}
+	if len(be.Backends) != 1 || be.Backends[0].Group != igLink {
+		t.Errorf("unexpected backends in backend service. expected one backend for %s, got: %v", igLink, be.Backends)
+	}
+	// TODO(nikhiljindal): Test update existing backend service.
+}

--- a/app/mci/pkg/gcp/backendservice/fake_backendservicesyncer.go
+++ b/app/mci/pkg/gcp/backendservice/fake_backendservicesyncer.go
@@ -1,0 +1,53 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backendservice
+
+import (
+	ingressbe "k8s.io/ingress-gce/pkg/backends"
+
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/mci/pkg/gcp/healthcheck"
+)
+
+type FakeBackendService struct {
+	LBName  string
+	Ports   []ingressbe.ServicePort
+	HCMap   healthcheck.HealthChecksMap
+	NPMap   NamedPortsMap
+	IGLinks []string
+}
+
+type FakeBackendServiceSyncer struct {
+	// List of backend services that this has been asked to ensure.
+	EnsuredBackendServices []FakeBackendService
+}
+
+// Fake backend service syncer to be used for tests.
+func NewFakeBackendServiceSyncer() BackendServiceSyncerInterface {
+	return &FakeBackendServiceSyncer{}
+}
+
+// Ensure this implements BackendServiceSyncerInterface.
+var _ BackendServiceSyncerInterface = &FakeBackendServiceSyncer{}
+
+func (h *FakeBackendServiceSyncer) EnsureBackendService(lbName string, ports []ingressbe.ServicePort, hcMap healthcheck.HealthChecksMap, npMap NamedPortsMap, igLinks []string) error {
+	h.EnsuredBackendServices = append(h.EnsuredBackendServices, FakeBackendService{
+		LBName:  lbName,
+		Ports:   ports,
+		HCMap:   hcMap,
+		NPMap:   npMap,
+		IGLinks: igLinks,
+	})
+	return nil
+}

--- a/app/mci/pkg/gcp/backendservice/interfaces.go
+++ b/app/mci/pkg/gcp/backendservice/interfaces.go
@@ -1,0 +1,31 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backendservice
+
+import (
+	"google.golang.org/api/compute/v1"
+	ingressbe "k8s.io/ingress-gce/pkg/backends"
+
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/mci/pkg/gcp/healthcheck"
+)
+
+// NamedPortsMap is a map of port number to the named port for that port.
+type NamedPortsMap map[int64]*compute.NamedPort
+
+// BackendServiceSyncerInterface is an interface to manage GCP backend services.
+type BackendServiceSyncerInterface interface {
+	// EnsureBackendService ensures that the required backend services exist.
+	EnsureBackendService(lbName string, ports []ingressbe.ServicePort, hcMap healthcheck.HealthChecksMap, npMap NamedPortsMap, igLinks []string) error
+}

--- a/app/mci/pkg/gcp/healthcheck/fake_healthchecksyncer.go
+++ b/app/mci/pkg/gcp/healthcheck/fake_healthchecksyncer.go
@@ -15,6 +15,7 @@
 package healthcheck
 
 import (
+	"google.golang.org/api/compute/v1"
 	ingressbe "k8s.io/ingress-gce/pkg/backends"
 )
 
@@ -36,12 +37,14 @@ func NewFakeHealthCheckSyncer() HealthCheckSyncerInterface {
 // Ensure this implements HealthCheckSyncerInterface.
 var _ HealthCheckSyncerInterface = &FakeHealthCheckSyncer{}
 
-func (h *FakeHealthCheckSyncer) EnsureHealthCheck(lbName string, ports []ingressbe.ServicePort, force bool) error {
+func (h *FakeHealthCheckSyncer) EnsureHealthCheck(lbName string, ports []ingressbe.ServicePort, force bool) (HealthChecksMap, error) {
+	hcMap := HealthChecksMap{}
 	for _, p := range ports {
 		h.EnsuredHealthChecks = append(h.EnsuredHealthChecks, FakeHealthCheck{
 			LBName: lbName,
 			Port:   p,
 		})
+		hcMap[p.Port] = &compute.HealthCheck{}
 	}
-	return nil
+	return hcMap, nil
 }

--- a/app/mci/pkg/gcp/healthcheck/healthchecksyncer_test.go
+++ b/app/mci/pkg/gcp/healthcheck/healthchecksyncer_test.go
@@ -82,7 +82,7 @@ func TestEnsureHealthCheck(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		err := hcs.EnsureHealthCheck(lbName, []ingressbe.ServicePort{
+		hcMap, err := hcs.EnsureHealthCheck(lbName, []ingressbe.ServicePort{
 			{
 				Port:     port,
 				Protocol: c.protocol,
@@ -92,9 +92,15 @@ func TestEnsureHealthCheck(t *testing.T) {
 			t.Errorf("error when: %v: EnsureHealthCheck({%v,%v}, %v) = [%v]. Want err? %t.",
 				c.desc, port, c.protocol, c.forceUpdate, err, c.ensureErr)
 		}
+		if c.ensureErr == false {
+			if len(hcMap) != 1 || hcMap[port] == nil {
+				t.Fatalf("error when %s: unexpected health check map: %v. Expected it to contain only the health check for port %d", c.desc, hcMap, port)
+			}
+		}
+
 		// Verify that GET does not return NotFound.
 		if _, err := hcp.GetHealthCheck(hcName); err != nil {
-			t.Fatalf("expected nil error, actual: %v", err)
+			t.Fatalf("error when %s: expected nil error, actual: %v", c.desc, err)
 		}
 
 	}

--- a/app/mci/pkg/gcp/healthcheck/interfaces.go
+++ b/app/mci/pkg/gcp/healthcheck/interfaces.go
@@ -15,11 +15,17 @@
 package healthcheck
 
 import (
+	"google.golang.org/api/compute/v1"
 	ingressbe "k8s.io/ingress-gce/pkg/backends"
 )
 
+// HealthChecksMap is a map of port number to the health check for that port.
+type HealthChecksMap map[int64]*compute.HealthCheck
+
 // HealthCheckSyncerInterface is an interface to manage GCP health checks.
 type HealthCheckSyncerInterface interface {
-	// EnsureHealthCheck ensures that the required health check exists.
-	EnsureHealthCheck(lbName string, ports []ingressbe.ServicePort, force bool) error
+	// EnsureHealthCheck ensures that the required health checks exist.
+	// Returns a map of port number to the health check for that port. The map contains all the ports for which  it was successfully able to ensure a health check.
+	// In case of no error, the map will contain all the ports from the given array of ports.
+	EnsureHealthCheck(lbName string, ports []ingressbe.ServicePort, forceUpdate bool) (HealthChecksMap, error)
 }

--- a/app/mci/pkg/gcp/loadbalancer/loadbalancersyncer.go
+++ b/app/mci/pkg/gcp/loadbalancer/loadbalancersyncer.go
@@ -17,9 +17,11 @@ package loadbalancer
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/golang/glog"
-
+	"github.com/hashicorp/go-multierror"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,15 +29,16 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	kubeclient "k8s.io/client-go/kubernetes"
 	ingressbe "k8s.io/ingress-gce/pkg/backends"
+	ingressig "k8s.io/ingress-gce/pkg/instances"
 	ingressutils "k8s.io/ingress-gce/pkg/utils"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/mci/pkg/gcp/backendservice"
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/mci/pkg/gcp/healthcheck"
 	utilsnamer "github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/mci/pkg/gcp/namer"
 )
 
 const (
-
 	// TODO: refactor code in kubernetes/ingress to reuse this.
 	// serviceApplicationProtocolKey is a stringified JSON map of port names to
 	// protocol names. Possible values are HTTP, HTTPS.
@@ -48,12 +51,25 @@ const (
 	// Prefix used by the namer to generate names.
 	// This is used to identify resources created by this code.
 	mciPrefix = "mci1"
+
+	// instanceGroupsAnnotationKey is the annotation key used by gclb ingress
+	// controller to specify the name and zone of instance groups created
+	// for the ingress.
+	// TODO(nikhiljindal): Refactor the code in kubernetes/ingress-gce to
+	// export it and then reuse it here.
+	instanceGroupsAnnotationKey = "ingress.gcp.kubernetes.io/instance-groups"
 )
 
 type LoadBalancerSyncer struct {
 	lbName string
-	hcs    healthcheck.HealthCheckSyncerInterface
+	// Health check syncer to sync the required health checks.
+	hcs healthcheck.HealthCheckSyncerInterface
+	// Backend service syncer to sync the required backend services.
+	bss backendservice.BackendServiceSyncerInterface
+	// kubernetes client to send requests to kubernetes apiserver.
 	client kubeclient.Interface
+	// Instance groups provider to call GCE APIs to manage GCE instance groups.
+	igp ingressig.InstanceGroups
 }
 
 func NewLoadBalancerSyncer(lbName string, client kubeclient.Interface, cloud *gce.GCECloud) *LoadBalancerSyncer {
@@ -61,17 +77,92 @@ func NewLoadBalancerSyncer(lbName string, client kubeclient.Interface, cloud *gc
 	return &LoadBalancerSyncer{
 		lbName: lbName,
 		hcs:    healthcheck.NewHealthCheckSyncer(namer, cloud),
+		bss:    backendservice.NewBackendServiceSyncer(namer, cloud),
 		client: client,
+		igp:    cloud,
 	}
 }
 
 func (l *LoadBalancerSyncer) CreateLoadBalancer(ing *v1beta1.Ingress, forceUpdate bool) error {
+	var err error
 	ports := l.ingToNodePorts(ing)
-	// Create health check to be used by the backend service.
-	if err := l.hcs.EnsureHealthCheck(l.lbName, ports, forceUpdate); err != nil {
-		return err
+	// Create health checks to be used by the backend service.
+	healthChecks, hcErr := l.hcs.EnsureHealthCheck(l.lbName, ports, forceUpdate)
+	if hcErr != nil {
+		// Keep aggregating errors and return all at the end, rather than giving up on the first error.
+		err = multierror.Append(err, hcErr)
+	}
+	igs, namedPorts, igErr := l.getIGsAndNamedPorts(ing)
+	// Cant really create any backend service without named ports. No point continuing.
+	if igErr != nil {
+		return multierror.Append(err, igErr)
+	}
+	// Create backend service. This should always be called after the health check since backend service needs to point to the health check.
+	if beErr := l.bss.EnsureBackendService(l.lbName, ports, healthChecks, namedPorts, igs); beErr != nil {
+		return multierror.Append(err, beErr)
 	}
 	return nil
+}
+
+// Returns links to all instance groups and named ports on any one of them.
+// Note that it picks an instance group at random and returns the named ports for that instance group, assuming that the named ports are same on all instance groups.
+// Also note that this returns all named ports on the instance group and not just the ones relevant to the given ingress.
+func (l *LoadBalancerSyncer) getIGsAndNamedPorts(ing *v1beta1.Ingress) ([]string, backendservice.NamedPortsMap, error) {
+	// Keep trying until ingress gets the instance group annotation.
+	// TODO(nikhiljindal): Check if we need exponential backoff.
+	for try := true; try; time.Sleep(1 * time.Second) {
+		// Fetch the ingress from a cluster.
+		ing, err := l.getIng(ing.Name, ing.Namespace)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error %s in fetching ingress", err)
+		}
+		if ing.Annotations == nil || ing.Annotations[instanceGroupsAnnotationKey] == "" {
+			// keep trying
+			fmt.Println("Waiting for ingress to get", instanceGroupsAnnotationKey, "annotation.....")
+			continue
+		}
+		annotationValue := ing.Annotations[instanceGroupsAnnotationKey]
+		glog.V(3).Infof("Found instance groups annotation value: %s", annotationValue)
+		// Get the instance group name.
+		type InstanceGroupsAnnotationValue struct {
+			Name string
+			Zone string
+		}
+		var values []InstanceGroupsAnnotationValue
+		if err := json.Unmarshal([]byte(annotationValue), &values); err != nil {
+			return nil, nil, fmt.Errorf("error in parsing annotation key %s, value %s: %s", instanceGroupsAnnotationKey, annotationValue, err)
+		}
+		if len(values) == 0 {
+			// keep trying
+			fmt.Printf("Waiting for ingress to get", instanceGroupsAnnotationKey, "annotation.....")
+			continue
+		}
+		// Compute link to all instance groups.
+		var igs []string
+		for _, ig := range values {
+			igs = append(igs, fmt.Sprintf("%s/instanceGroups/%s", ig.Zone, ig.Name))
+		}
+		// Compute named ports from the first instance group.
+		zone := getZoneFromURL(values[0].Zone)
+		ig, err := l.igp.GetInstanceGroup(values[0].Name, zone)
+		if err != nil {
+			return nil, nil, err
+		}
+		fmt.Printf("Fetched instance group: %s/%s, got named ports: %#v", zone, values[0].Name, ig.NamedPorts)
+		namedPorts := backendservice.NamedPortsMap{}
+		for _, np := range ig.NamedPorts {
+			namedPorts[np.Port] = np
+		}
+		return igs, namedPorts, nil
+	}
+	return nil, nil, nil
+}
+
+// Returns the zone from a GCP Zone URL.
+func getZoneFromURL(zoneURL string) string {
+	// Split the string by "/" and return the last element.
+	components := strings.Split(zoneURL, "/")
+	return components[len(components)-1]
 }
 
 func (l *LoadBalancerSyncer) ingToNodePorts(ing *v1beta1.Ingress) []ingressbe.ServicePort {
@@ -161,4 +252,8 @@ PortLoop:
 
 func (l *LoadBalancerSyncer) getSvc(svcName, nsName string) (*v1.Service, error) {
 	return l.client.CoreV1().Services(nsName).Get(svcName, metav1.GetOptions{})
+}
+
+func (l *LoadBalancerSyncer) getIng(ingName, nsName string) (*v1beta1.Ingress, error) {
+	return l.client.ExtensionsV1beta1().Ingresses(nsName).Get(ingName, metav1.GetOptions{})
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 3c6eec9c760547a876b44b2eebf721610730f78ed421b60e9c42a6df97c87b68
-updated: 2017-10-17T20:52:01.87121538-07:00
+hash: fbc28d16109ef7109ede1aa69a895d4e8a5db48f409169d15d8c80cee4b70269
+updated: 2017-10-20T14:03:51.805331954-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -173,18 +173,13 @@ imports:
   version: 654f863362977d69086620b5f72f13e911da2410
   subpackages:
   - cloudkms/v1
-  - cloudmonitoring/v2beta2
   - compute/v0.alpha
   - compute/v0.beta
   - compute/v1
   - container/v1
-  - dns/v1
   - gensupport
   - googleapi
   - googleapi/internal/uritemplates
-  - logging/v2beta1
-  - monitoring/v3
-  - pubsub/v1
 - name: google.golang.org/appengine
   version: a2e0dc829727a4f957a7428b1f322805cfc1f362
   subpackages:
@@ -388,7 +383,10 @@ imports:
 - name: k8s.io/ingress-gce
   version: 27d32ecbc079df4766152894f5c039b252fb2c07
   subpackages:
+  - pkg/backends
   - pkg/healthchecks
+  - pkg/instances
+  - pkg/storage
   - pkg/utils
 - name: k8s.io/kube-openapi
   version: 868f2f29720b192240e18284659231b440f9cda5

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,12 +1,4 @@
-package: .
-ignore:
-- k8s-multi-cluster-ingress/app/mci/cmd
-- k8s-multi-cluster-ingress/cmd/mci/app
-- k8s-multi-cluster-ingress/app/mci/pkg/gcp/interface
-- k8s-multi-cluster-ingress/app/mci/pkg/gcp/loadbalancer
-- k8s-multi-cluster-ingress/app/mci/pkg/gcp/namer
-- k8s-multi-cluster-ingress/app/mci/pkg/serviceport
-- k8s-multi-cluster-ingress/app/mci/pkg/gcp/healthcheck
+package: github.com/GoogleCloudPlatform/k8s-multicluster-ingress
 import:
 - package: github.com/spf13/cobra
 - package: github.com/spf13/pflag


### PR DESCRIPTION
This uses the created health checks and instance groups annotation on the ingress to create the relevant backend service.

Verified by running `mci create` that it creates the backend service as expected.

cc @G-Harmon @madhusudancs @csbell 