### PR TITLE
Adding code to create Target http proxies

### DIFF
--- a/app/mci/pkg/gcp/namer/namer.go
+++ b/app/mci/pkg/gcp/namer/namer.go
@@ -19,9 +19,11 @@ import (
 )
 
 const (
-	hcPrefix      = "hc"
-	backendPrefix = "be"
-	urlMapPrefix  = "um"
+	hcPrefix               = "hc"
+	backendPrefix          = "be"
+	urlMapPrefix           = "um"
+	targetHttpProxyPrefix  = "tp"
+	targetHttpsProxyPrefix = "tps"
 
 	// A delimiter used for clarity in naming GCE resources.
 	lbNameDelimiter = "--"
@@ -65,6 +67,14 @@ func (n *Namer) BeServiceName(port int64) string {
 
 func (n *Namer) URLMapName() string {
 	return n.decorateName(fmt.Sprintf("%v-%v", n.prefix, urlMapPrefix))
+}
+
+func (n *Namer) TargetHttpProxyName() string {
+	return n.decorateName(fmt.Sprintf("%v-%v", n.prefix, targetHttpProxyPrefix))
+}
+
+func (n *Namer) TargetHttpsProxyName() string {
+	return n.decorateName(fmt.Sprintf("%v-%v", n.prefix, targetHttpsProxyPrefix))
 }
 
 func (n *Namer) decorateName(name string) string {

--- a/app/mci/pkg/gcp/targetproxy/fake_targetproxysyncer.go
+++ b/app/mci/pkg/gcp/targetproxy/fake_targetproxysyncer.go
@@ -1,0 +1,41 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package targetproxy
+
+type FakeTargetProxy struct {
+	LBName string
+	UmLink string
+}
+
+type FakeTargetProxySyncer struct {
+	// List of target proxies that this has been asked to ensure.
+	EnsuredTargetProxies []FakeTargetProxy
+}
+
+// Fake target proxy syncer to be used for tests.
+func NewFakeTargetProxySyncer() TargetProxySyncerInterface {
+	return &FakeTargetProxySyncer{}
+}
+
+// Ensure this implements TargetProxySyncerInterface.
+var _ TargetProxySyncerInterface = &FakeTargetProxySyncer{}
+
+func (f *FakeTargetProxySyncer) EnsureTargetProxy(lbName, umLink string) error {
+	f.EnsuredTargetProxies = append(f.EnsuredTargetProxies, FakeTargetProxy{
+		LBName: lbName,
+		UmLink: umLink,
+	})
+	return nil
+}

--- a/app/mci/pkg/gcp/targetproxy/interfaces.go
+++ b/app/mci/pkg/gcp/targetproxy/interfaces.go
@@ -12,18 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package urlmap
+package targetproxy
 
-import (
-	"k8s.io/api/extensions/v1beta1"
-
-	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/mci/pkg/gcp/backendservice"
-)
-
-// URLMapSyncerInterface is an interface to manage GCP url maps.
-type URLMapSyncerInterface interface {
-	// EnsureURLMap ensures that the required url map exists for the given ingress.
-	// Uses beMap to extract the backend services to link to in the url map.
-	// Returns the self link for the ensured url map.
-	EnsureURLMap(lbName string, ing *v1beta1.Ingress, beMap backendservice.BackendServicesMap) (string, error)
+// TargetProxySyncerInterface is an interface to manage GCP target proxies.
+type TargetProxySyncerInterface interface {
+	// EnsureTargetProxy ensures that the required target proxy exists for the given load balancer and url map link.
+	EnsureTargetProxy(lbName, urlMapLink string) error
 }

--- a/app/mci/pkg/gcp/targetproxy/targetproxysyncer.go
+++ b/app/mci/pkg/gcp/targetproxy/targetproxysyncer.go
@@ -1,0 +1,126 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package targetproxy
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/hashicorp/go-multierror"
+	"google.golang.org/api/compute/v1"
+	ingresslb "k8s.io/ingress-gce/pkg/loadbalancers"
+
+	utilsnamer "github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/mci/pkg/gcp/namer"
+)
+
+type TargetProxySyncer struct {
+	namer *utilsnamer.Namer
+	// Target proxies provider to call GCP APIs to manipulate target proxies.
+	tpp ingresslb.LoadBalancers
+}
+
+func NewTargetProxySyncer(namer *utilsnamer.Namer, tpp ingresslb.LoadBalancers) TargetProxySyncerInterface {
+	return &TargetProxySyncer{
+		namer: namer,
+		tpp:   tpp,
+	}
+}
+
+// Ensure this implements TargetProxySyncerInterface.
+var _ TargetProxySyncerInterface = &TargetProxySyncer{}
+
+// EnsureTargetProxy ensures that the required target proxies exist for the given url map.
+// Does nothing if it exists already, else creates a new one.
+func (s *TargetProxySyncer) EnsureTargetProxy(lbName, umLink string) error {
+	fmt.Println("Ensuring target proxies")
+	// TODO(nikhiljindal): Support creating https proxies.
+	fmt.Println("Warning: We create http proxies only, even if https was requested.")
+	var err error
+	if httpProxyErr := s.ensureHttpProxy(lbName, umLink); httpProxyErr != nil {
+		httpProxyErr = fmt.Errorf("Error in ensuring http target proxy: %s", httpProxyErr)
+		// Try ensuring both http and https target proxies and return all errors at once.
+		err = multierror.Append(err, httpProxyErr)
+	}
+	return err
+}
+
+// ensureHttpProxy ensures that the required target proxy exists for the given port.
+// Does nothing if it exists already, else creates a new one.
+func (s *TargetProxySyncer) ensureHttpProxy(lbName, umLink string) error {
+	fmt.Println("Ensuring target http proxy")
+	desiredHttpProxy := s.desiredHttpTargetProxy(lbName, umLink)
+	name := desiredHttpProxy.Name
+	// Check if target proxy already exists.
+	existingHttpProxy, err := s.tpp.GetTargetHttpProxy(name)
+	if err == nil {
+		fmt.Println("Target proxy", name, "exists already. Checking if it matches our desired target proxy")
+		glog.V(5).Infof("Existing target proxy: %v\n, desired target proxy: %v", existingHttpProxy, *desiredHttpProxy)
+		// Target proxy with that name exists already. Check if it matches what we want.
+		if targetHttpProxyMatches(desiredHttpProxy, existingHttpProxy) {
+			// Nothing to do. Desired target proxy exists already.
+			fmt.Println("Desired target proxy exists already")
+			return nil
+		}
+		// TODO (nikhiljindal): Require explicit permission from user before doing this.
+		fmt.Println("Updating existing target proxy", name, "to match the desired state")
+		return s.updateHttpTargetProxy(desiredHttpProxy)
+	}
+	glog.V(5).Infof("Got error %s while trying to get existing target proxy %s", err, name)
+	// TODO(nikhiljindal): Handle non NotFound errors. We should create only if the error is NotFound.
+	// Create the target proxy.
+	fmt.Println("Creating target proxy", name)
+	glog.V(5).Infof("Creating target proxy %v", *desiredHttpProxy)
+	return s.createHttpTargetProxy(desiredHttpProxy)
+}
+
+func (s *TargetProxySyncer) updateHttpTargetProxy(desiredHttpProxy *compute.TargetHttpProxy) error {
+	name := desiredHttpProxy.Name
+	fmt.Println("Updating existing target http proxy", name, "to match the desired state")
+	// There is no UpdateTargetHttpProxy method.
+	// Apart from name, UrlMap is the only field that can be different. We update that field directly.
+	err := s.tpp.SetUrlMapForTargetHttpProxy(desiredHttpProxy, &compute.UrlMap{SelfLink: desiredHttpProxy.UrlMap})
+	if err != nil {
+		return err
+	}
+	fmt.Println("Target http proxy", name, "updated successfully")
+	return nil
+}
+
+func (s *TargetProxySyncer) createHttpTargetProxy(desiredHttpProxy *compute.TargetHttpProxy) error {
+	name := desiredHttpProxy.Name
+	fmt.Println("Creating target http proxy", name)
+	glog.V(5).Infof("Creating target http proxy %v", desiredHttpProxy)
+	err := s.tpp.CreateTargetHttpProxy(desiredHttpProxy)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Target http proxy", name, "created successfully")
+	return nil
+}
+
+func targetHttpProxyMatches(desiredHttpProxy, existingHttpProxy *compute.TargetHttpProxy) bool {
+	// TODO(nikhiljindal): Add proper logic to figure out if the 2 target proxies match.
+	// Need to add the --force flag for user to consent overritting before this method can be updated to return false.
+	return true
+}
+
+func (s *TargetProxySyncer) desiredHttpTargetProxy(lbName, umLink string) *compute.TargetHttpProxy {
+	// Compute the desired target http proxy.
+	return &compute.TargetHttpProxy{
+		Name:        s.namer.TargetHttpProxyName(),
+		Description: fmt.Sprintf("Target http proxy for kubernetes multicluster loadbalancer %s", lbName),
+		UrlMap:      umLink,
+	}
+}

--- a/app/mci/pkg/gcp/targetproxy/targetproxysyncer_test.go
+++ b/app/mci/pkg/gcp/targetproxy/targetproxysyncer_test.go
@@ -1,0 +1,50 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package targetproxy
+
+import (
+	"testing"
+
+	ingresslb "k8s.io/ingress-gce/pkg/loadbalancers"
+
+	utilsnamer "github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/mci/pkg/gcp/namer"
+)
+
+func TestEnsureTargetHttpProxy(t *testing.T) {
+	lbName := "lb-name"
+	umLink := "selfLink"
+	// Should create the target proxy as expected.
+	tpp := ingresslb.NewFakeLoadBalancers("")
+	namer := utilsnamer.NewNamer("mci", lbName)
+	tpName := namer.TargetHttpProxyName()
+	tps := NewTargetProxySyncer(namer, tpp)
+	// GET should return NotFound.
+	if _, err := tpp.GetTargetHttpProxy(tpName); err == nil {
+		t.Fatalf("expected NotFound error, got nil")
+	}
+	err := tps.EnsureTargetProxy(lbName, umLink)
+	if err != nil {
+		t.Fatalf("expected no error in ensuring target proxy, actual: %v", err)
+	}
+	// Verify that GET does not return NotFound.
+	tp, err := tpp.GetTargetHttpProxy(tpName)
+	if err != nil {
+		t.Fatalf("expected nil error, actual: %v", err)
+	}
+	if tp.UrlMap != umLink {
+		t.Fatalf("unexpected UrlMap link in target proxy. expected: %s, actual: %s", umLink, tp.UrlMap)
+	}
+	// TODO(nikhiljindal): Test update existing target proxy.
+}

--- a/app/mci/pkg/gcp/urlmap/fake_urlmapsyncer.go
+++ b/app/mci/pkg/gcp/urlmap/fake_urlmapsyncer.go
@@ -20,6 +20,10 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/mci/pkg/gcp/backendservice"
 )
 
+const (
+	FakeUrlSelfLink = "selfLink"
+)
+
 type FakeURLMap struct {
 	LBName  string
 	Ingress *v1beta1.Ingress
@@ -39,11 +43,11 @@ func NewFakeURLMapSyncer() URLMapSyncerInterface {
 // Ensure this implements URLMapSyncerInterface.
 var _ URLMapSyncerInterface = &FakeURLMapSyncer{}
 
-func (f *FakeURLMapSyncer) EnsureURLMap(lbName string, ing *v1beta1.Ingress, beMap backendservice.BackendServicesMap) error {
+func (f *FakeURLMapSyncer) EnsureURLMap(lbName string, ing *v1beta1.Ingress, beMap backendservice.BackendServicesMap) (string, error) {
 	f.EnsuredURLMaps = append(f.EnsuredURLMaps, FakeURLMap{
 		LBName:  lbName,
 		Ingress: ing,
 		BeMap:   beMap,
 	})
-	return nil
+	return FakeUrlSelfLink, nil
 }

--- a/app/mci/pkg/gcp/urlmap/urlmapsyncer_test.go
+++ b/app/mci/pkg/gcp/urlmap/urlmapsyncer_test.go
@@ -50,14 +50,17 @@ func TestEnsureURLMap(t *testing.T) {
 	if _, err := ump.GetUrlMap(umName); err == nil {
 		t.Fatalf("expected NotFound error, got nil")
 	}
-	err := ums.EnsureURLMap(lbName, ing, beMap)
+	umLink, err := ums.EnsureURLMap(lbName, ing, beMap)
 	if err != nil {
 		t.Fatalf("expected no error in ensuring url map, actual: %v", err)
 	}
 	// Verify that GET does not return NotFound.
-	if _, err := ump.GetUrlMap(umName); err != nil {
+	um, err := ump.GetUrlMap(umName)
+	if err != nil {
 		t.Fatalf("expected nil error, actual: %v", err)
 	}
-	// TODO(nikhiljindal): Verify that the returned urlmap is as expected.
+	if um.SelfLink != umLink {
+		t.Errorf("unexpected self link in returned url map. expected: %s, got: %s", umLink, um.SelfLink)
+	}
 	// TODO(nikhiljindal): Test update existing url map.
 }


### PR DESCRIPTION
This uses the URLMap created in https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/pull/7 to create target proxies.

This PR contains logic to create HTTP proxies only. HTTPS proxies require additional logic of managing SSL certs. Will add support for that in a separate PR.

cc @bowei @nicksardo @csbell @G-Harmon @madhusudancs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/9)
<!-- Reviewable:end -->
