### PR TITLE
Fixing http-only target proxy and forwarding rule warning

### DIFF
--- a/app/mci/pkg/gcp/forwardingrule/fake_forwardingrulesyncer.go
+++ b/app/mci/pkg/gcp/forwardingrule/fake_forwardingrulesyncer.go
@@ -33,7 +33,7 @@ func NewFakeForwardingRuleSyncer() ForwardingRuleSyncerInterface {
 // Ensure this implements ForwardingRuleSyncerInterface.
 var _ ForwardingRuleSyncerInterface = &FakeForwardingRuleSyncer{}
 
-func (f *FakeForwardingRuleSyncer) EnsureForwardingRule(lbName, ipAddress, targetProxyLink string) error {
+func (f *FakeForwardingRuleSyncer) EnsureHttpForwardingRule(lbName, ipAddress, targetProxyLink string) error {
 	f.EnsuredForwardingRules = append(f.EnsuredForwardingRules, FakeForwardingRule{
 		LBName:    lbName,
 		IPAddress: ipAddress,

--- a/app/mci/pkg/gcp/forwardingrule/forwardingrulesyncer.go
+++ b/app/mci/pkg/gcp/forwardingrule/forwardingrulesyncer.go
@@ -48,12 +48,10 @@ func NewForwardingRuleSyncer(namer *utilsnamer.Namer, frp ingresslb.LoadBalancer
 // Ensure this implements ForwardingRuleSyncerInterface.
 var _ ForwardingRuleSyncerInterface = &ForwardingRuleSyncer{}
 
-// EnsureForwardingRule ensures that the required forwarding rule exists.
+// EnsureHttpForwardingRule ensures that the required http forwarding rule exists.
 // Does nothing if it exists already, else creates a new one.
-func (s *ForwardingRuleSyncer) EnsureForwardingRule(lbName, ipAddress, targetProxyLink string) error {
-	fmt.Println("Ensuring forwarding rule")
-	// TODO(nikhiljindal): Support creating https forwarding rules.
-	fmt.Println("Warning: We create http forwarding rules only, even if https was requested.")
+func (s *ForwardingRuleSyncer) EnsureHttpForwardingRule(lbName, ipAddress, targetProxyLink string) error {
+	fmt.Println("Ensuring http forwarding rule")
 	desiredFR := s.desiredForwardingRule(lbName, ipAddress, targetProxyLink)
 	name := desiredFR.Name
 	// Check if forwarding rule already exists.

--- a/app/mci/pkg/gcp/forwardingrule/forwardingrulesyncer_test.go
+++ b/app/mci/pkg/gcp/forwardingrule/forwardingrulesyncer_test.go
@@ -22,7 +22,7 @@ import (
 	utilsnamer "github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/mci/pkg/gcp/namer"
 )
 
-func TestEnsureForwardingRule(t *testing.T) {
+func TestEnsureHttpForwardingRule(t *testing.T) {
 	lbName := "lb-name"
 	ipAddr := "192.168.0.0"
 	tpLink := "fakeLink"
@@ -35,7 +35,7 @@ func TestEnsureForwardingRule(t *testing.T) {
 	if _, err := frp.GetGlobalForwardingRule(frName); err == nil {
 		t.Fatalf("expected NotFound error, got nil")
 	}
-	err := frs.EnsureForwardingRule(lbName, ipAddr, tpLink)
+	err := frs.EnsureHttpForwardingRule(lbName, ipAddr, tpLink)
 	if err != nil {
 		t.Fatalf("expected no error in ensuring forwarding rule, actual: %v", err)
 	}

--- a/app/mci/pkg/gcp/forwardingrule/interfaces.go
+++ b/app/mci/pkg/gcp/forwardingrule/interfaces.go
@@ -16,6 +16,6 @@ package forwardingrule
 
 // ForwardingRuleSyncerInterface is an interface to manage GCP forwarding rules.
 type ForwardingRuleSyncerInterface interface {
-	// EnsureForwardingRule ensures that the required forwarding rule exists.
-	EnsureForwardingRule(lbName, ipAddress, targetProxyLink string) error
+	// EnsureHttpForwardingRule ensures that the required http forwarding rule exists.
+	EnsureHttpForwardingRule(lbName, ipAddress, targetProxyLink string) error
 }

--- a/app/mci/pkg/gcp/loadbalancer/loadbalancersyncer_test.go
+++ b/app/mci/pkg/gcp/loadbalancer/loadbalancersyncer_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	"k8s.io/ingress-gce/pkg/annotations"
 	ingressig "k8s.io/ingress-gce/pkg/instances"
 	ingresslb "k8s.io/ingress-gce/pkg/loadbalancers"
 
@@ -85,8 +86,8 @@ func TestCreateLoadBalancer(t *testing.T) {
 			Name:      "my-ing",
 			Namespace: "my-ns",
 			Annotations: map[string]string{
-				instanceGroupsAnnotationKey: string(jsonValue),
-				staticIPNameKey:             ipAddress.Name,
+				annotations.InstanceGroupsAnnotationKey: string(jsonValue),
+				annotations.StaticIPNameKey:             ipAddress.Name,
 			},
 		},
 		Spec: v1beta1.IngressSpec{

--- a/app/mci/pkg/gcp/targetproxy/fake_targetproxysyncer.go
+++ b/app/mci/pkg/gcp/targetproxy/fake_targetproxysyncer.go
@@ -36,7 +36,7 @@ func NewFakeTargetProxySyncer() TargetProxySyncerInterface {
 // Ensure this implements TargetProxySyncerInterface.
 var _ TargetProxySyncerInterface = &FakeTargetProxySyncer{}
 
-func (f *FakeTargetProxySyncer) EnsureTargetProxy(lbName, umLink string) (string, error) {
+func (f *FakeTargetProxySyncer) EnsureHttpTargetProxy(lbName, umLink string) (string, error) {
 	f.EnsuredTargetProxies = append(f.EnsuredTargetProxies, FakeTargetProxy{
 		LBName: lbName,
 		UmLink: umLink,

--- a/app/mci/pkg/gcp/targetproxy/interfaces.go
+++ b/app/mci/pkg/gcp/targetproxy/interfaces.go
@@ -16,7 +16,7 @@ package targetproxy
 
 // TargetProxySyncerInterface is an interface to manage GCP target proxies.
 type TargetProxySyncerInterface interface {
-	// EnsureTargetProxy ensures that the required target proxy exists for the given load balancer and url map link.
+	// EnsureHttpTargetProxy ensures that the required http target proxy exists for the given load balancer and url map link.
 	// Returns the self link for the ensured proxy.
-	EnsureTargetProxy(lbName, urlMapLink string) (string, error)
+	EnsureHttpTargetProxy(lbName, urlMapLink string) (string, error)
 }

--- a/app/mci/pkg/gcp/targetproxy/targetproxysyncer.go
+++ b/app/mci/pkg/gcp/targetproxy/targetproxysyncer.go
@@ -41,12 +41,10 @@ func NewTargetProxySyncer(namer *utilsnamer.Namer, tpp ingresslb.LoadBalancers) 
 // Ensure this implements TargetProxySyncerInterface.
 var _ TargetProxySyncerInterface = &TargetProxySyncer{}
 
-// EnsureTargetProxy ensures that the required target proxies exist for the given url map.
+// EnsureHttpTargetProxy ensures that the required http target proxy exists for the given url map.
 // Does nothing if it exists already, else creates a new one.
-func (s *TargetProxySyncer) EnsureTargetProxy(lbName, umLink string) (string, error) {
-	fmt.Println("Ensuring target proxies")
-	// TODO(nikhiljindal): Support creating https proxies.
-	fmt.Println("Warning: We create http proxies only, even if https was requested.")
+func (s *TargetProxySyncer) EnsureHttpTargetProxy(lbName, umLink string) (string, error) {
+	fmt.Println("Ensuring http target proxy")
 	var err error
 	tpLink, httpProxyErr := s.ensureHttpProxy(lbName, umLink)
 	if httpProxyErr != nil {

--- a/app/mci/pkg/gcp/targetproxy/targetproxysyncer_test.go
+++ b/app/mci/pkg/gcp/targetproxy/targetproxysyncer_test.go
@@ -34,7 +34,7 @@ func TestEnsureTargetHttpProxy(t *testing.T) {
 	if _, err := tpp.GetTargetHttpProxy(tpName); err == nil {
 		t.Fatalf("expected NotFound error, got nil")
 	}
-	tpLink, err := tps.EnsureTargetProxy(lbName, umLink)
+	tpLink, err := tps.EnsureHttpTargetProxy(lbName, umLink)
 	if err != nil {
 		t.Fatalf("expected no error in ensuring target proxy, actual: %v", err)
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: fbc28d16109ef7109ede1aa69a895d4e8a5db48f409169d15d8c80cee4b70269
-updated: 2017-10-20T14:03:51.805331954-07:00
+hash: 7845ab3f3640d4a97f6291b96c52cfb67ba5dd895263c08108f4c6f09335d62f
+updated: 2017-10-25T23:10:58.198078773-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -381,11 +381,12 @@ imports:
   - util/integer
   - util/retry
 - name: k8s.io/ingress-gce
-  version: 27d32ecbc079df4766152894f5c039b252fb2c07
+  version: 6cad689da446bfc6367df62ceb340b606e91753e
   subpackages:
   - pkg/backends
   - pkg/healthchecks
   - pkg/instances
+  - pkg/loadbalancers
   - pkg/storage
   - pkg/utils
 - name: k8s.io/kube-openapi

--- a/vendor/k8s.io/ingress-gce/pkg/annotations/annotations.go
+++ b/vendor/k8s.io/ingress-gce/pkg/annotations/annotations.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"k8s.io/ingress-gce/pkg/utils"
+)
+
+const (
+	// AllowHTTPKey tells the Ingress controller to allow/block HTTP access.
+	// If either unset or set to true, the controller will create a
+	// forwarding-rule for port 80, and any additional rules based on the TLS
+	// section of the Ingress. If set to false, the controller will only create
+	// rules for port 443 based on the TLS section.
+	AllowHTTPKey = "kubernetes.io/ingress.allow-http"
+
+	// StaticIPNameKey tells the Ingress controller to use a specific GCE
+	// static ip for its forwarding rules. If specified, the Ingress controller
+	// assigns the static ip by this name to the forwarding rules of the given
+	// Ingress. The controller *does not* manage this ip, it is the users
+	// responsibility to create/delete it.
+	StaticIPNameKey = "kubernetes.io/ingress.global-static-ip-name"
+
+	// PreSharedCertKey represents the specific pre-shared SSL
+	// certicate for the Ingress controller to use. The controller *does not*
+	// manage this certificate, it is the users responsibility to create/delete it.
+	// In GCP, the Ingress controller assigns the SSL certificate with this name
+	// to the target proxies of the Ingress.
+	PreSharedCertKey = "ingress.gcp.kubernetes.io/pre-shared-cert"
+
+	// ServiceApplicationProtocolKey is a stringified JSON map of port names to
+	// protocol strings. Possible values are HTTP, HTTPS
+	// Example:
+	// '{"my-https-port":"HTTPS","my-http-port":"HTTP"}'
+	ServiceApplicationProtocolKey = "service.alpha.kubernetes.io/app-protocols"
+
+	// IngressClassKey picks a specific "class" for the Ingress. The controller
+	// only processes Ingresses with this annotation either unset, or set
+	// to either gceIngessClass or the empty string.
+	IngressClassKey      = "kubernetes.io/ingress.class"
+	GceIngressClass      = "gce"
+	GceMultiIngressClass = "gce-multi-cluster"
+
+	// Label key to denote which GCE zone a Kubernetes node is in.
+	ZoneKey     = "failure-domain.beta.kubernetes.io/zone"
+	DefaultZone = ""
+
+	// InstanceGroupsAnnotationKey is the annotation key used by controller to
+	// specify the name and zone of instance groups created for the ingress.
+	// This is read only for users. Controller will overrite any user updates.
+	// This is only set for ingresses with ingressClass = "gce-multi-cluster"
+	InstanceGroupsAnnotationKey = "ingress.gcp.kubernetes.io/instance-groups"
+)
+
+// IngAnnotations represents ingress annotations.
+type IngAnnotations map[string]string
+
+// AllowHTTP returns the allowHTTP flag. True by default.
+func (ing IngAnnotations) AllowHTTP() bool {
+	val, ok := ing[AllowHTTPKey]
+	if !ok {
+		return true
+	}
+	v, err := strconv.ParseBool(val)
+	if err != nil {
+		return true
+	}
+	return v
+}
+
+// UseNamedTLS returns the name of the GCE SSL certificate. Empty by default.
+func (ing IngAnnotations) UseNamedTLS() string {
+	val, ok := ing[PreSharedCertKey]
+	if !ok {
+		return ""
+	}
+
+	return val
+}
+
+func (ing IngAnnotations) StaticIPName() string {
+	val, ok := ing[StaticIPNameKey]
+	if !ok {
+		return ""
+	}
+	return val
+}
+
+func (ing IngAnnotations) IngressClass() string {
+	val, ok := ing[IngressClassKey]
+	if !ok {
+		return ""
+	}
+	return val
+}
+
+// SvcAnnotations represents Service annotations.
+type SvcAnnotations map[string]string
+
+func (svc SvcAnnotations) ApplicationProtocols() (map[string]utils.AppProtocol, error) {
+	val, ok := svc[ServiceApplicationProtocolKey]
+	if !ok {
+		return map[string]utils.AppProtocol{}, nil
+	}
+
+	var portToProtos map[string]utils.AppProtocol
+	err := json.Unmarshal([]byte(val), &portToProtos)
+
+	// Verify protocol is an accepted value
+	for _, proto := range portToProtos {
+		switch proto {
+		case utils.ProtocolHTTP, utils.ProtocolHTTPS:
+		default:
+			return nil, fmt.Errorf("invalid port application protocol: %v", proto)
+		}
+	}
+
+	return portToProtos, err
+}

--- a/vendor/k8s.io/ingress-gce/pkg/backends/fakes.go
+++ b/vendor/k8s.io/ingress-gce/pkg/backends/fakes.go
@@ -17,8 +17,6 @@ limitations under the License.
 package backends
 
 import (
-	"fmt"
-
 	compute "google.golang.org/api/compute/v1"
 	api_v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -49,7 +47,7 @@ func (f *FakeBackendServices) GetGlobalBackendService(name string) (*compute.Bac
 	f.calls = append(f.calls, utils.Get)
 	obj, exists, err := f.backendServices.GetByKey(name)
 	if !exists {
-		return nil, fmt.Errorf("backend service %v not found", name)
+		return nil, utils.FakeGoogleAPINotFoundErr()
 	}
 	if err != nil {
 		return nil, err
@@ -59,7 +57,7 @@ func (f *FakeBackendServices) GetGlobalBackendService(name string) (*compute.Bac
 	if name == svc.Name {
 		return svc, nil
 	}
-	return nil, fmt.Errorf("backend service %v not found", name)
+	return nil, utils.FakeGoogleAPINotFoundErr()
 }
 
 // CreateGlobalBackendService fakes backend service creation.
@@ -79,7 +77,7 @@ func (f *FakeBackendServices) DeleteGlobalBackendService(name string) error {
 	f.calls = append(f.calls, utils.Delete)
 	svc, exists, err := f.backendServices.GetByKey(name)
 	if !exists {
-		return fmt.Errorf("backend service %v not found", name)
+		return utils.FakeGoogleAPINotFoundErr()
 	}
 	if err != nil {
 		return err

--- a/vendor/k8s.io/ingress-gce/pkg/controller/controller_test.go
+++ b/vendor/k8s.io/ingress-gce/pkg/controller/controller_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/kubernetes/pkg/api"
 
+	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/context"
 	"k8s.io/ingress-gce/pkg/firewalls"
 	"k8s.io/ingress-gce/pkg/loadbalancers"
@@ -429,7 +430,7 @@ func TestLbChangeStaticIP(t *testing.T) {
 		t.Fatalf("Expected 2 forwarding rules with the same IP.")
 	}
 
-	ing.Annotations = map[string]string{staticIPNameKey: "testip"}
+	ing.Annotations = map[string]string{annotations.StaticIPNameKey: "testip"}
 	cm.fakeLbs.ReserveGlobalAddress(&compute.Address{Name: "testip", Address: "1.2.3.4"})
 
 	// Second sync reassigns 1.2.3.4 to existing forwarding rule (by recreating it)

--- a/vendor/k8s.io/ingress-gce/pkg/controller/utils_test.go
+++ b/vendor/k8s.io/ingress-gce/pkg/controller/utils_test.go
@@ -27,6 +27,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/ingress-gce/pkg/annotations"
 	"k8s.io/ingress-gce/pkg/backends"
 	"k8s.io/ingress-gce/pkg/utils"
 )
@@ -242,7 +243,7 @@ func addNodes(lbc *LoadBalancerController, zoneToNode map[string][]string) {
 				ObjectMeta: meta_v1.ObjectMeta{
 					Name: node,
 					Labels: map[string]string{
-						zoneKey: zone,
+						annotations.ZoneKey: zone,
 					},
 				},
 				Status: api_v1.NodeStatus{
@@ -290,13 +291,13 @@ func TestAddInstanceGroupsAnnotation(t *testing.T) {
 		},
 	}
 	for _, c := range testCases {
-		annotations := map[string]string{}
-		err := setInstanceGroupsAnnotation(annotations, c.Igs)
+		ingAnnotations := map[string]string{}
+		err := setInstanceGroupsAnnotation(ingAnnotations, c.Igs)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
-		if annotations[instanceGroupsAnnotationKey] != c.ExpectedAnnotation {
-			t.Fatalf("Unexpected annotation value: %s, expected: %s", annotations[instanceGroupsAnnotationKey], c.ExpectedAnnotation)
+		if ingAnnotations[annotations.InstanceGroupsAnnotationKey] != c.ExpectedAnnotation {
+			t.Fatalf("Unexpected annotation value: %s, expected: %s", ingAnnotations[annotations.InstanceGroupsAnnotationKey], c.ExpectedAnnotation)
 		}
 	}
 }

--- a/vendor/k8s.io/ingress-gce/pkg/healthchecks/fakes.go
+++ b/vendor/k8s.io/ingress-gce/pkg/healthchecks/fakes.go
@@ -18,12 +18,9 @@ package healthchecks
 
 import (
 	compute "google.golang.org/api/compute/v1"
-	"google.golang.org/api/googleapi"
-)
 
-func fakeNotFoundErr() *googleapi.Error {
-	return &googleapi.Error{Code: 404}
-}
+	"k8s.io/ingress-gce/pkg/utils"
+)
 
 // NewFakeHealthCheckProvider returns a new FakeHealthChecks.
 func NewFakeHealthCheckProvider() *FakeHealthCheckProvider {
@@ -53,13 +50,13 @@ func (f *FakeHealthCheckProvider) GetHttpHealthCheck(name string) (*compute.Http
 		return &hc, nil
 	}
 
-	return nil, fakeNotFoundErr()
+	return nil, utils.FakeGoogleAPINotFoundErr()
 }
 
 // DeleteHttpHealthCheck fakes out deleting a http health check.
 func (f *FakeHealthCheckProvider) DeleteHttpHealthCheck(name string) error {
 	if _, exists := f.http[name]; !exists {
-		return fakeNotFoundErr()
+		return utils.FakeGoogleAPINotFoundErr()
 	}
 
 	delete(f.http, name)
@@ -69,7 +66,7 @@ func (f *FakeHealthCheckProvider) DeleteHttpHealthCheck(name string) error {
 // UpdateHttpHealthCheck sends the given health check as an update.
 func (f *FakeHealthCheckProvider) UpdateHttpHealthCheck(hc *compute.HttpHealthCheck) error {
 	if _, exists := f.http[hc.Name]; !exists {
-		return fakeNotFoundErr()
+		return utils.FakeGoogleAPINotFoundErr()
 	}
 
 	f.http[hc.Name] = *hc
@@ -90,13 +87,13 @@ func (f *FakeHealthCheckProvider) GetHealthCheck(name string) (*compute.HealthCh
 		return &hc, nil
 	}
 
-	return nil, fakeNotFoundErr()
+	return nil, utils.FakeGoogleAPINotFoundErr()
 }
 
 // DeleteHealthCheck fakes out deleting a http health check.
 func (f *FakeHealthCheckProvider) DeleteHealthCheck(name string) error {
 	if _, exists := f.generic[name]; !exists {
-		return fakeNotFoundErr()
+		return utils.FakeGoogleAPINotFoundErr()
 	}
 
 	delete(f.generic, name)
@@ -106,7 +103,7 @@ func (f *FakeHealthCheckProvider) DeleteHealthCheck(name string) error {
 // UpdateHealthCheck sends the given health check as an update.
 func (f *FakeHealthCheckProvider) UpdateHealthCheck(hc *compute.HealthCheck) error {
 	if _, exists := f.generic[hc.Name]; !exists {
-		return fakeNotFoundErr()
+		return utils.FakeGoogleAPINotFoundErr()
 	}
 
 	f.generic[hc.Name] = *hc

--- a/vendor/k8s.io/ingress-gce/pkg/loadbalancers/fakes.go
+++ b/vendor/k8s.io/ingress-gce/pkg/loadbalancers/fakes.go
@@ -110,7 +110,7 @@ func (f *FakeLoadBalancers) GetGlobalForwardingRule(name string) (*compute.Forwa
 			return f.Fw[i], nil
 		}
 	}
-	return nil, fmt.Errorf("forwarding rule %v not found", name)
+	return nil, utils.FakeGoogleAPINotFoundErr()
 }
 
 // CreateGlobalForwardingRule fakes forwarding rule creation.
@@ -170,7 +170,7 @@ func (f *FakeLoadBalancers) GetUrlMap(name string) (*compute.UrlMap, error) {
 			return f.Um[i], nil
 		}
 	}
-	return nil, fmt.Errorf("url map %v not found", name)
+	return nil, utils.FakeGoogleAPINotFoundErr()
 }
 
 // CreateUrlMap fakes url-map creation.
@@ -190,7 +190,7 @@ func (f *FakeLoadBalancers) UpdateUrlMap(urlMap *compute.UrlMap) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("url map %v not found", urlMap.Name)
+	return utils.FakeGoogleAPINotFoundErr()
 }
 
 // DeleteUrlMap fakes url-map deletion.
@@ -216,7 +216,7 @@ func (f *FakeLoadBalancers) GetTargetHttpProxy(name string) (*compute.TargetHttp
 			return f.Tp[i], nil
 		}
 	}
-	return nil, fmt.Errorf("target http proxy %v not found", name)
+	return nil, utils.FakeGoogleAPINotFoundErr()
 }
 
 // CreateTargetHttpProxy fakes creating a target http proxy.
@@ -261,7 +261,7 @@ func (f *FakeLoadBalancers) GetTargetHttpsProxy(name string) (*compute.TargetHtt
 			return f.Tps[i], nil
 		}
 	}
-	return nil, fmt.Errorf("target https proxy %v not found", name)
+	return nil, utils.FakeGoogleAPINotFoundErr()
 }
 
 // CreateTargetHttpsProxy fakes creating a target http proxy.
@@ -307,7 +307,7 @@ func (f *FakeLoadBalancers) SetSslCertificateForTargetHttpsProxy(proxy *compute.
 		}
 	}
 	if !found {
-		return fmt.Errorf("failed to find proxy %v", proxy.Name)
+		return utils.FakeGoogleAPINotFoundErr()
 	}
 	return nil
 }
@@ -392,7 +392,7 @@ func (f *FakeLoadBalancers) GetGlobalAddress(name string) (*compute.Address, err
 			return f.IP[i], nil
 		}
 	}
-	return nil, fmt.Errorf("static IP %v not found", name)
+	return nil, utils.FakeGoogleAPINotFoundErr()
 }
 
 // DeleteGlobalAddress fakes out static IP deletion.
@@ -418,7 +418,7 @@ func (f *FakeLoadBalancers) GetSslCertificate(name string) (*compute.SslCertific
 			return f.Certs[i], nil
 		}
 	}
-	return nil, fmt.Errorf("cert %v not found", name)
+	return nil, utils.FakeGoogleAPINotFoundErr()
 }
 
 // CreateSslCertificate fakes out certificate creation.


### PR DESCRIPTION
Updated the code to detect when https was explicitly requested by user and generate a more meaningful error in that case rather than a generic always on warning.

Ran `glide update` to fetch latest code from kubernetes/ingress-gce to include https://github.com/kubernetes/ingress-gce/pull/58.
Also used the updated code to remove a bunch of TODOs for duplicated annotation keys.

cc @csbell @G-Harmon @madhusudancs 