### PR TITLE
Adding logic for get status command

### DIFF
--- a/app/mci/cmd/cmd.go
+++ b/app/mci/cmd/cmd.go
@@ -35,5 +35,6 @@ func NewCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	}
 	rootCmd.AddCommand(NewCmdCreate(out, err))
 	rootCmd.AddCommand(NewCmdDelete(out, err))
+	rootCmd.AddCommand(NewCmdGetStatus(out, err))
 	return rootCmd
 }

--- a/app/mci/cmd/delete.go
+++ b/app/mci/cmd/delete.go
@@ -110,7 +110,7 @@ func RunDelete(options *DeleteOptions, args []string) error {
 	}
 	cloudInterface, err := cloudinterface.NewGCECloudInterface(options.GCPProject)
 	if err != nil {
-		return fmt.Errorf("error in deleting cloud interface: %s", err)
+		return fmt.Errorf("error in creating cloud interface: %s", err)
 	}
 
 	// Delete ingress in all clusters.

--- a/app/mci/cmd/getstatus.go
+++ b/app/mci/cmd/getstatus.go
@@ -1,0 +1,100 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/mci/pkg/gcp/cloudinterface"
+	gcplb "github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/mci/pkg/gcp/loadbalancer"
+)
+
+var (
+	getStatusShortDescription = "Get the status of an existing multicluster ingress."
+	getStatusLongDescription  = `Get the status of an existing multicluster ingress.
+
+	Takes as input the name of the load balancer and prints its status (ip address, list of clusters it is spread to, etc).
+	`
+)
+
+type GetStatusOptions struct {
+	// Name of the load balancer.
+	// Required.
+	LBName string
+	// Name of the GCP project in which the load balancer should be configured.
+	// Required
+	// TODO(nikhiljindal): This should be optional. Figure it out from gcloud settings.
+	GCPProject string
+}
+
+func NewCmdGetStatus(out, err io.Writer) *cobra.Command {
+	var options GetStatusOptions
+
+	cmd := &cobra.Command{
+		Use:   "get-status",
+		Short: getStatusShortDescription,
+		Long:  getStatusLongDescription,
+		// TODO(nikhiljindal): Add an example.
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := ValidateGetStatusArgs(&options, args); err != nil {
+				fmt.Println(err)
+				return
+			}
+			if err := RunGetStatus(&options, args); err != nil {
+				fmt.Println("Error in getting status of the load balancer:", err)
+			}
+		},
+	}
+	AddGetStatusFlags(cmd, &options)
+	return cmd
+}
+
+func AddGetStatusFlags(cmd *cobra.Command, options *GetStatusOptions) error {
+	// TODO(nikhiljindal): Add a short flag "-p" if it seems useful.
+	cmd.Flags().StringVarP(&options.GCPProject, "gcp-project", "", options.GCPProject, "name of the gcp project")
+	// TODO Add a verbose flag that turns on glog logging.
+	return nil
+}
+
+func ValidateGetStatusArgs(options *GetStatusOptions, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("unexpected args: %v. Expected one arg as name of load balancer.", args)
+	}
+	// Verify that the required params are not missing.
+	if options.GCPProject == "" {
+		return fmt.Errorf("unexpected missing argument gcp-project.")
+	}
+	return nil
+}
+
+func RunGetStatus(options *GetStatusOptions, args []string) error {
+	options.LBName = args[0]
+
+	cloudInterface, err := cloudinterface.NewGCECloudInterface(options.GCPProject)
+	if err != nil {
+		return fmt.Errorf("error in creating cloud interface: %s", err)
+	}
+
+	lbs := gcplb.NewLoadBalancerSyncer(options.LBName, nil /* clientset */, cloudInterface)
+	status, err := lbs.PrintStatus()
+	if err != nil {
+		return err
+	}
+	fmt.Println(status)
+	return nil
+}

--- a/app/mci/cmd/getstatus_test.go
+++ b/app/mci/cmd/getstatus_test.go
@@ -1,0 +1,49 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+)
+
+func TestValidateGetStatusArgs(t *testing.T) {
+	// ValidateGetStatusArgs should return an error with empty options.
+	options := GetStatusOptions{}
+	if err := ValidateGetStatusArgs(&options, []string{}); err == nil {
+		t.Errorf("Expected error for emtpy options")
+	}
+
+	// ValidateGetStatusArgs should return an error with missing load balancer name.
+	options = GetStatusOptions{
+		GCPProject: "gcp-project",
+	}
+	if err := ValidateGetStatusArgs(&options, []string{}); err == nil {
+		t.Errorf("Expected error for missing load balancer name")
+	}
+
+	// ValidateGetStatusArgs should return an error with missing gcp project.
+	options = GetStatusOptions{}
+	if err := ValidateGetStatusArgs(&options, []string{"lbname"}); err == nil {
+		t.Errorf("Expected error for missing gcp-project")
+	}
+
+	// ValidateGetStatusArgs should succeed when all arguments are passed as expected.
+	options = GetStatusOptions{
+		GCPProject: "gcp-project",
+	}
+	if err := ValidateGetStatusArgs(&options, []string{"lbname"}); err != nil {
+		t.Errorf("unexpected error from ValidateGetStatusArgs: %s", err)
+	}
+}

--- a/app/mci/pkg/gcp/forwardingrule/forwardingrulesyncer_test.go
+++ b/app/mci/pkg/gcp/forwardingrule/forwardingrulesyncer_test.go
@@ -15,17 +15,20 @@
 package forwardingrule
 
 import (
+	"reflect"
 	"testing"
 
 	ingresslb "k8s.io/ingress-gce/pkg/loadbalancers"
 
 	utilsnamer "github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/mci/pkg/gcp/namer"
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/mci/pkg/gcp/status"
 )
 
 func TestEnsureHttpForwardingRule(t *testing.T) {
 	lbName := "lb-name"
 	ipAddr := "1.2.3.4"
 	tpLink := "fakeLink"
+	clusters := []string{"cluster1", "cluster2"}
 	// Should create the forwarding rule as expected.
 	frp := ingresslb.NewFakeLoadBalancers("")
 	namer := utilsnamer.NewNamer("mci", lbName)
@@ -35,7 +38,7 @@ func TestEnsureHttpForwardingRule(t *testing.T) {
 	if _, err := frp.GetGlobalForwardingRule(frName); err == nil {
 		t.Fatalf("expected NotFound error, got nil")
 	}
-	err := frs.EnsureHttpForwardingRule(lbName, ipAddr, tpLink)
+	err := frs.EnsureHttpForwardingRule(lbName, ipAddr, tpLink, clusters)
 	if err != nil {
 		t.Fatalf("expected no error in ensuring forwarding rule, actual: %v", err)
 	}
@@ -50,7 +53,18 @@ func TestEnsureHttpForwardingRule(t *testing.T) {
 	if fr.Target != tpLink {
 		t.Errorf("unexpected target proxy link. expected: %s, got: %s", tpLink, fr.Target)
 	}
-	// TODO(nikhiljindal): Test update existing forwarding rule.
+	expectedDescr := status.LoadBalancerStatus{
+		LoadBalancerName: lbName,
+		Clusters:         clusters,
+		IPAddress:        ipAddr,
+	}
+	status, err := status.FromString(fr.Description)
+	if err != nil {
+		t.Fatalf("unexpected error %s in unmarshalling forwarding rule description %v", err, fr.Description)
+	}
+	if status.LoadBalancerName != expectedDescr.LoadBalancerName || !reflect.DeepEqual(status.Clusters, expectedDescr.Clusters) || status.IPAddress != expectedDescr.IPAddress {
+		t.Fatalf("unexpected description: %v, expected: %v", status, expectedDescr)
+	}
 }
 
 func TestDeleteForwardingRule(t *testing.T) {
@@ -62,7 +76,7 @@ func TestDeleteForwardingRule(t *testing.T) {
 	namer := utilsnamer.NewNamer("mci", lbName)
 	frName := namer.HttpForwardingRuleName()
 	frs := NewForwardingRuleSyncer(namer, frp)
-	if err := frs.EnsureHttpForwardingRule(lbName, ipAddr, tpLink); err != nil {
+	if err := frs.EnsureHttpForwardingRule(lbName, ipAddr, tpLink, []string{}); err != nil {
 		t.Fatalf("expected no error in ensuring forwarding rule, actual: %v", err)
 	}
 	if _, err := frp.GetGlobalForwardingRule(frName); err != nil {
@@ -74,5 +88,33 @@ func TestDeleteForwardingRule(t *testing.T) {
 	}
 	if _, err := frp.GetGlobalForwardingRule(frName); err == nil {
 		t.Fatalf("expected not found error, actual: nil")
+	}
+}
+
+func TestGetLoadBalancerStatus(t *testing.T) {
+	lbName := "lb-name"
+	ipAddr := "1.2.3.4"
+	tpLink := "fakeLink"
+	clusters := []string{"cluster1", "cluster2"}
+	// Should create the forwarding rule as expected.
+	frp := ingresslb.NewFakeLoadBalancers("")
+	namer := utilsnamer.NewNamer("mci", lbName)
+	frs := NewForwardingRuleSyncer(namer, frp)
+	if err := frs.EnsureHttpForwardingRule(lbName, ipAddr, tpLink, clusters); err != nil {
+		t.Fatalf("expected no error in ensuring forwarding rule, actual: %v", err)
+	}
+	status, err := frs.GetLoadBalancerStatus(lbName)
+	if err != nil {
+		t.Fatalf("unexpected error in getting status description for load balancer %s", lbName)
+	}
+	// Verify that status description has the expected values set.
+	if status.LoadBalancerName != lbName {
+		t.Errorf("unexpected load balancer name, expected: %s, got: %s", lbName, status.LoadBalancerName)
+	}
+	if !reflect.DeepEqual(status.Clusters, clusters) {
+		t.Errorf("unexpected list of clusters, expected: %v, got: %v", clusters, status.Clusters)
+	}
+	if status.IPAddress != ipAddr {
+		t.Errorf("unpexpected ip address, expected: %s, got: %s", status.IPAddress, ipAddr)
 	}
 }

--- a/app/mci/pkg/gcp/forwardingrule/interfaces.go
+++ b/app/mci/pkg/gcp/forwardingrule/interfaces.go
@@ -14,10 +14,17 @@
 
 package forwardingrule
 
+import (
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/mci/pkg/gcp/status"
+)
+
 // ForwardingRuleSyncerInterface is an interface to manage GCP forwarding rules.
 type ForwardingRuleSyncerInterface interface {
 	// EnsureHttpForwardingRule ensures that the required http forwarding rule exists.
-	EnsureHttpForwardingRule(lbName, ipAddress, targetProxyLink string) error
+	// clusters is the list of clusters across which the load balancer is spread.
+	EnsureHttpForwardingRule(lbName, ipAddress, targetProxyLink string, clusters []string) error
 	// DeleteForwardingRules deletes the forwarding rules that EnsureForwardingRule would have created.
 	DeleteForwardingRules() error
+	// GetLoadBalancerStatus returns the struct describing the status of the given load balancer.
+	GetLoadBalancerStatus(lbName string) (*status.LoadBalancerStatus, error)
 }

--- a/app/mci/pkg/gcp/loadbalancer/loadbalancersyncer_test.go
+++ b/app/mci/pkg/gcp/loadbalancer/loadbalancersyncer_test.go
@@ -17,6 +17,7 @@ package loadbalancer
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"google.golang.org/api/compute/v1"
@@ -58,6 +59,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 	igName := "my-fake-ig"
 	igZone := "my-fake-zone"
 	zoneLink := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/fake-project/zones/%s", igZone)
+	clusters := []string{"cluster1", "cluster2"}
 	lbc := newLoadBalancerSyncer(lbName)
 	ipAddress := &compute.Address{
 		Name:    "ipAddressName",
@@ -69,7 +71,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
-	if err := lbc.CreateLoadBalancer(ing, true /*forceUpdate*/); err != nil {
+	if err := lbc.CreateLoadBalancer(ing, true /*forceUpdate*/, clusters); err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}
 	// Verify client actions.
@@ -153,6 +155,9 @@ func TestCreateLoadBalancer(t *testing.T) {
 	}
 	if fr.LBName != lbName {
 		t.Errorf("unexpected lbname in forwarding rule. expected: %s, got: %s", lbName, fr.LBName)
+	}
+	if !reflect.DeepEqual(fr.Clusters, clusters) {
+		t.Errorf("unexpected clusters in forwarding rule. expected: %v, got: %v", clusters, fr.Clusters)
 	}
 }
 
@@ -253,7 +258,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
-	if err := lbc.CreateLoadBalancer(ing, true /*forceUpdate*/); err != nil {
+	if err := lbc.CreateLoadBalancer(ing, true /*forceUpdate*/, []string{}); err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}
 	fhc := lbc.hcs.(*healthcheck.FakeHealthCheckSyncer)

--- a/app/mci/pkg/gcp/status/loadbalancerstatus.go
+++ b/app/mci/pkg/gcp/status/loadbalancerstatus.go
@@ -1,0 +1,37 @@
+package status
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Struct to describe a multi cluster load balancer.
+type LoadBalancerStatus struct {
+	// Human readable description for this status.
+	// If we are using the description field of a GCP resource to store this status,
+	// then this description field can be used to store the description about that GCP resource.
+	Description string
+	// Name of the load balancer which is described by this.
+	LoadBalancerName string
+	// Name of the clusters across which this load balancer is spread.
+	Clusters []string
+	// IP Address of this load balancer.
+	IPAddress string
+	// TODO: Store errors that were generated during creating and deleting this load balancer.
+}
+
+func (s LoadBalancerStatus) ToString() (string, error) {
+	jsonValue, err := json.Marshal(s)
+	if err != nil {
+		return "", fmt.Errorf("error %s in marshalling status description %v", err, s)
+	}
+	return string(jsonValue), nil
+}
+
+func FromString(str string) (*LoadBalancerStatus, error) {
+	var s LoadBalancerStatus
+	if err := json.Unmarshal([]byte(str), &s); err != nil {
+		return nil, fmt.Errorf("error %s in unmarshalling string %s", err, str)
+	}
+	return &s, nil
+}


### PR DESCRIPTION
Adding a `get-status` command that prints information about the load balancer.
It prints the IP address and list of clusters that it is spread to.

Using ForwardingRule.Description to store this information.

cc @nicksardo @bowei @csbell @madhusudancs @G-Harmon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/14)
<!-- Reviewable:end -->
