### PR TITLE
Updating the default health check path to match that used by glbc ingress controller

### DIFF
--- a/app/kubemci/pkg/gcp/healthcheck/healthchecksyncer.go
+++ b/app/kubemci/pkg/gcp/healthcheck/healthchecksyncer.go
@@ -207,13 +207,13 @@ func (h *HealthCheckSyncer) desiredHealthCheck(lbName string, port ingressbe.Ser
 	case "HTTP":
 		hc.HttpHealthCheck = &compute.HTTPHealthCheck{
 			Port:        port.Port,
-			RequestPath: "/healthz", // TODO(nikhiljindal): Allow customization.
+			RequestPath: "/", // TODO(nikhiljindal): Allow customization.
 		}
 		break
 	case "HTTPS":
 		hc.HttpsHealthCheck = &compute.HTTPSHealthCheck{
-			Port:        port.Port,  // TODO(nikhiljindal): Allow customization.
-			RequestPath: "/healthz", // TODO(nikhiljindal): Allow customization.
+			Port:        port.Port, // TODO(nikhiljindal): Allow customization.
+			RequestPath: "/",       // TODO(nikhiljindal): Allow customization.
 		}
 		break
 	default:


### PR DESCRIPTION
Updating the default health check path from `/healthz` to `/` to match that used by glbc kubernetes ingress controller: https://github.com/kubernetes/ingress-gce/blob/b0603c69382a39d097063eab8e3d9e30ca1cdf7b/cmd/glbc/main.go#L131.

This enables users to use their existing ingress yamls that work with single kubernetes cluster, with kubemci.

cc @csbell @G-Harmon @madhusudancs @mdelio