### PR TITLE
Add --force support to backendServiceSyncer.

### DIFF
--- a/app/kubemci/cmd/create.go
+++ b/app/kubemci/cmd/create.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -198,7 +198,7 @@ func createIngressInClusters(kubeconfig string, ing *v1beta1.Ingress, clusters [
 	clients := map[string]kubeclient.Interface{}
 	var err error
 	for _, c := range clusters {
-		fmt.Println("\nHandling context:", c)
+		glog.V(4).Infof("Creating Ingress in cluster: %v...", c)
 		client, clientErr := getClientset(kubeconfig, c)
 		if clientErr != nil {
 			err = multierror.Append(err, fmt.Errorf("Error getting kubectl client interface for context %s:", c, clientErr))
@@ -216,6 +216,7 @@ func createIngressInClusters(kubeconfig string, ing *v1beta1.Ingress, clusters [
 				err = multierror.Append(err, fmt.Errorf("Error in creating ingress in cluster %s: %s", c, createErr))
 			}
 		}
+		fmt.Println("Created Ingress for cluster:", c)
 	}
 	return clients, err
 }

--- a/app/kubemci/pkg/gcp/backendservice/backendservicesyncer.go
+++ b/app/kubemci/pkg/gcp/backendservice/backendservicesyncer.go
@@ -15,11 +15,14 @@
 package backendservice
 
 import (
+	"encoding/json"
 	"fmt"
+	"reflect"
+
+	compute "google.golang.org/api/compute/v1"
 
 	"github.com/golang/glog"
-	"github.com/hashicorp/go-multierror"
-	"google.golang.org/api/compute/v1"
+	multierror "github.com/hashicorp/go-multierror"
 	ingressbe "k8s.io/ingress-gce/pkg/backends"
 
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/healthcheck"
@@ -43,10 +46,8 @@ func NewBackendServiceSyncer(namer *utilsnamer.Namer, bsp ingressbe.BackendServi
 // Ensure this implements BackendServiceSyncerInterface.
 var _ BackendServiceSyncerInterface = &BackendServiceSyncer{}
 
-// EnsureBackendService ensures that the required backend services exist for the given ports.
-// Does nothing if they exist already, else creates new ones.
-// Returns a map of the kubernetes service name to the corresponding GCE backend service.
-func (b *BackendServiceSyncer) EnsureBackendService(lbName string, ports []ingressbe.ServicePort, hcMap healthcheck.HealthChecksMap, npMap NamedPortsMap, igLinks []string) (BackendServicesMap, error) {
+// See interface comment.
+func (b *BackendServiceSyncer) EnsureBackendService(lbName string, ports []ingressbe.ServicePort, hcMap healthcheck.HealthChecksMap, npMap NamedPortsMap, igLinks []string, forceUpdate bool) (BackendServicesMap, error) {
 	fmt.Println("Ensuring backend services")
 	glog.V(5).Infof("Received health checks map: %v", hcMap)
 	glog.V(5).Infof("Received named ports map: %v", npMap)
@@ -54,7 +55,7 @@ func (b *BackendServiceSyncer) EnsureBackendService(lbName string, ports []ingre
 	var err error
 	ensuredBackendServices := BackendServicesMap{}
 	for _, p := range ports {
-		be, beErr := b.ensureBackendService(lbName, p, hcMap[p.Port], npMap[p.Port], igLinks)
+		be, beErr := b.ensureBackendService(lbName, p, hcMap[p.Port], npMap[p.Port], igLinks, forceUpdate)
 		if beErr != nil {
 			beErr = fmt.Errorf("Error %s in ensuring backend service for port %v", beErr, p)
 			// Try ensuring backend services for all ports and return all errors at once.
@@ -95,8 +96,9 @@ func (b *BackendServiceSyncer) deleteBackendService(port ingressbe.ServicePort) 
 }
 
 // ensureBackendService ensures that the required backend service exists for the given port.
-// Does nothing if it exists already, else creates a new one.
-func (b *BackendServiceSyncer) ensureBackendService(lbName string, port ingressbe.ServicePort, hc *compute.HealthCheck, np *compute.NamedPort, igLinks []string) (*compute.BackendService, error) {
+// If it doesn't exist, creates one. If it already exists and is up to date,
+// does nothing. If it exists, it will only be updated if forceUpdate is true.
+func (b *BackendServiceSyncer) ensureBackendService(lbName string, port ingressbe.ServicePort, hc *compute.HealthCheck, np *compute.NamedPort, igLinks []string, forceUpdate bool) (*compute.BackendService, error) {
 	fmt.Println("Ensuring backend service for port:", port)
 	if hc == nil {
 		return nil, fmt.Errorf("missing health check probably due to an error in creating health check. Cannot create backend service without health chech link")
@@ -114,15 +116,34 @@ func (b *BackendServiceSyncer) ensureBackendService(lbName string, port ingressb
 	existingBE, err := b.bsp.GetGlobalBackendService(name)
 	if err == nil {
 		fmt.Println("Backend service", name, "exists already. Checking if it matches our desired backend service")
-		glog.V(5).Infof("Existing backend service: %v\n, desired backend service: %v", existingBE, *desiredBE)
+		jsonExisting, mErr := json.Marshal(existingBE)
+		if mErr != nil {
+			glog.Infof("Error marshaling existing backend: %v", mErr)
+		}
+		jsonDesired, mErr := json.Marshal(desiredBE)
+		if mErr != nil {
+			glog.Infof("Error marshalling desired backend: %v", mErr)
+		}
+		glog.V(5).Infof("Existing backend service:\n%s\nDesired backend service:\n%s", jsonExisting, jsonDesired)
 		// Backend service with that name exists already. Check if it matches what we want.
 		if backendServiceMatches(desiredBE, existingBE) {
 			// Nothing to do. Desired backend service exists already.
-			fmt.Println("Desired backend service exists already")
+			fmt.Println("Desired backend service exists already. Nothing to do.")
 			return existingBE, nil
 		}
-		// TODO (nikhiljindal): Require explicit permission from user before doing this.
-		return b.updateBackendService(desiredBE)
+		if forceUpdate {
+			// TODO(G-Harmon): Figure out how to properly calculate the fp. Using Sha256 returned a googleapi error.
+			desiredBE.Fingerprint = existingBE.Fingerprint
+			fmt.Println("Updating existing backend service", name, "to match the desired state (since --force specified)")
+			return b.updateBackendService(desiredBE)
+		} else {
+			// TODO(G-Harmon): Show diff to user and prompt yes/no for overwriting.
+			fmt.Println("Will not overwrite a differing BackendService without the --force flag.")
+			// TODO(G-Harmon): share json-formatting logic with code above.
+			glog.V(5).Infof("Desired backend service:\n%+v\nExisting backend service:\n%+v",
+				desiredBE, existingBE)
+			return nil, fmt.Errorf("will not overwrite BackendService without --force")
+		}
 	}
 	glog.V(5).Infof("Got error %s while trying to get existing backend service %s", err, name)
 	// TODO(nikhiljindal): Handle non NotFound errors. We should create only if the error is NotFound.
@@ -133,9 +154,10 @@ func (b *BackendServiceSyncer) ensureBackendService(lbName string, port ingressb
 // updateBackendService updates the backend service and returns the updated backend service.
 func (b *BackendServiceSyncer) updateBackendService(desiredBE *compute.BackendService) (*compute.BackendService, error) {
 	name := desiredBE.Name
-	fmt.Println("Updating existing backend service", name, "to match the desired state")
 	err := b.bsp.UpdateGlobalBackendService(desiredBE)
 	if err != nil {
+		// TODO(G-Harmon): Errors should probably go to STDERR.
+		fmt.Printf("Error from UpdateGlobalBackendService: %s\n", err)
 		return nil, err
 	}
 	fmt.Println("Backend service", name, "updated successfully")
@@ -156,9 +178,27 @@ func (b *BackendServiceSyncer) createBackendService(desiredBE *compute.BackendSe
 }
 
 func backendServiceMatches(desiredBE, existingBE *compute.BackendService) bool {
-	// TODO(nikhiljindal): Add proper logic to figure out if the 2 backend services match.
-	// Need to add the --force flag for user to consent overritting before this method can be updated to return false.
-	return true
+	return desiredBE.AffinityCookieTtlSec == existingBE.AffinityCookieTtlSec &&
+		reflect.DeepEqual(desiredBE.Backends, existingBE.Backends) &&
+		reflect.DeepEqual(desiredBE.CdnPolicy, existingBE.CdnPolicy) &&
+		reflect.DeepEqual(desiredBE.ConnectionDraining, existingBE.ConnectionDraining) &&
+		desiredBE.Description == existingBE.Description &&
+		desiredBE.EnableCDN == existingBE.EnableCDN &&
+		// TODO(G-Harmon): Check fingerprint? fp is not required for
+		// insert but is required for update. Seems like we don't have
+		// to check it.
+		reflect.DeepEqual(desiredBE.HealthChecks, existingBE.HealthChecks) &&
+		((desiredBE.Iap == nil && existingBE.Iap == nil) ||
+			(desiredBE.Iap.Enabled == existingBE.Iap.Enabled &&
+				desiredBE.Iap.Oauth2ClientId == existingBE.Iap.Oauth2ClientId &&
+				desiredBE.Iap.Oauth2ClientSecret == existingBE.Iap.Oauth2ClientSecret)) &&
+		desiredBE.LoadBalancingScheme == existingBE.LoadBalancingScheme &&
+		desiredBE.Name == existingBE.Name &&
+		desiredBE.Port == existingBE.Port &&
+		desiredBE.PortName == existingBE.PortName &&
+		desiredBE.Protocol == existingBE.Protocol &&
+		desiredBE.SessionAffinity == existingBE.SessionAffinity &&
+		desiredBE.TimeoutSec == existingBE.TimeoutSec
 }
 
 func (b *BackendServiceSyncer) desiredBackendService(lbName string, port ingressbe.ServicePort, hcLink, portName string, igLinks []string) *compute.BackendService {
@@ -171,6 +211,13 @@ func (b *BackendServiceSyncer) desiredBackendService(lbName string, port ingress
 		Port:         port.Port,
 		PortName:     portName,
 		Backends:     desiredBackends(igLinks),
+		// We have to fill in these fields so we can properly compare to what's returned to us.
+		// TODO(G-Harmon): We should get these values from existing if it exists and skip them otherwise, rather than hardcoding them here.
+		ConnectionDraining:  &compute.ConnectionDraining{},
+		Kind:                "compute#backendService",
+		LoadBalancingScheme: "EXTERNAL",
+		SessionAffinity:     "NONE",
+		TimeoutSec:          30,
 	}
 }
 
@@ -186,6 +233,8 @@ func desiredBackends(igLinks []string) []*compute.Backend {
 			// instances.
 			BalancingMode:      "RATE",
 			MaxRatePerInstance: 1e14,
+			// We have to fill in these fields so we can properly compare to what's returned to us
+			CapacityScaler: 1,
 		})
 	}
 	return backends

--- a/app/kubemci/pkg/gcp/backendservice/backendservicesyncer_test.go
+++ b/app/kubemci/pkg/gcp/backendservice/backendservicesyncer_test.go
@@ -17,12 +17,14 @@ package backendservice
 import (
 	"testing"
 
-	"google.golang.org/api/compute/v1"
+	compute "google.golang.org/api/compute/v1"
+
 	"k8s.io/apimachinery/pkg/types"
 	ingressbe "k8s.io/ingress-gce/pkg/backends"
 
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/healthcheck"
 	utilsnamer "github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/namer"
+	"github.com/golang/glog"
 )
 
 func TestEnsureBackendService(t *testing.T) {
@@ -30,7 +32,6 @@ func TestEnsureBackendService(t *testing.T) {
 	port := int64(32211)
 	portName := "portName"
 	igLink := "igLink"
-	hcLink := "hcLink"
 	kubeSvcName := "ingress-svc"
 	// Should create the backend service as expected.
 	bsp := ingressbe.NewFakeBackendServices(func(op int, be *compute.BackendService) error { return nil })
@@ -41,44 +42,86 @@ func TestEnsureBackendService(t *testing.T) {
 	if _, err := bsp.GetGlobalBackendService(beName); err == nil {
 		t.Fatalf("expected NotFound error, actual: nil")
 	}
-	beMap, err := bss.EnsureBackendService(lbName, []ingressbe.ServicePort{
+
+	testCases := []struct {
+		desc string
+		// In's
+		hcLink      string
+		forceUpdate bool
+		// Out's
+		ensureErr bool
+	}{
 		{
-			Port:     port,
-			Protocol: "HTTP",
-			SvcName:  types.NamespacedName{Name: kubeSvcName},
+			desc:        "Initial BE Creation",
+			hcLink:      "hcLink",
+			forceUpdate: false,
+			ensureErr:   false,
 		},
-	}, healthcheck.HealthChecksMap{
-		port: &compute.HealthCheck{
-			SelfLink: hcLink,
+		{
+			desc:        "ensureBackend: no work to do",
+			hcLink:      "hcLink",
+			forceUpdate: false,
+			ensureErr:   false,
 		},
-	}, NamedPortsMap{
-		port: &compute.NamedPort{
-			Port: port,
-			Name: portName,
+		{
+			desc:        "Change backend (force=true)",
+			hcLink:      "different hcLink",
+			forceUpdate: true,
+			ensureErr:   false,
 		},
-	}, []string{igLink})
-	if err != nil {
-		t.Fatalf("expected no error in ensuring backend service, actual: %v", err)
+		{
+			desc:        "Attempt backend change with (force=false) fails",
+			hcLink:      "hcLink the 3rd",
+			forceUpdate: false,
+			ensureErr:   true,
+		},
 	}
-	// Verify that the created backend service is as expected.
-	_, err = bsp.GetGlobalBackendService(beName)
-	if err != nil {
-		t.Fatalf("expected nil error, actual: %v", err)
+
+	for _, c := range testCases {
+		glog.Infof("test case starting:%v", c.desc)
+		beMap, err := bss.EnsureBackendService(lbName, []ingressbe.ServicePort{
+			{
+				Port:     port,
+				Protocol: "HTTP",
+				SvcName:  types.NamespacedName{Name: kubeSvcName},
+			},
+		}, healthcheck.HealthChecksMap{
+			port: &compute.HealthCheck{
+				SelfLink: c.hcLink,
+			},
+		}, NamedPortsMap{
+			port: &compute.NamedPort{
+				Port: port,
+				Name: portName,
+			},
+		}, []string{igLink}, c.forceUpdate)
+		if (err != nil) != c.ensureErr {
+			t.Errorf("expected an error, got:%v, in ensuring backend service, actual: %v", err)
+		}
+		if c.ensureErr {
+			// Can't do validation if we expected an error.
+			continue
+		}
+		_, err = bsp.GetGlobalBackendService(beName)
+		if err != nil {
+			t.Errorf("expected nil GetGlobalBackendSvc error, actual: %v", err)
+			continue
+		}
+		if len(beMap) != 1 || beMap[kubeSvcName] == nil {
+			t.Errorf("unexpected backend service map: %v. Expected it to contain only the backend service for kube service %s", beMap, kubeSvcName)
+			continue
+		}
+		be := beMap[kubeSvcName]
+		if len(be.HealthChecks) != 1 || be.HealthChecks[0] != c.hcLink {
+			t.Errorf("unexpected health check in backend service. expected: %s, got: %v", c.hcLink, be.HealthChecks)
+		}
+		if be.Port != port || be.PortName != portName {
+			t.Errorf("unexpected port and port name, expected: %s/%s, got: %s/%s", portName, port, be.PortName, be.Port)
+		}
+		if len(be.Backends) != 1 || be.Backends[0].Group != igLink {
+			t.Errorf("unexpected backends in backend service. expected one backend for %s, got: %v", igLink, be.Backends)
+		}
 	}
-	if len(beMap) != 1 || beMap[kubeSvcName] == nil {
-		t.Fatalf("unexpected backend service map: %v. Expected it to contain only the backend service for kube service %s", beMap, kubeSvcName)
-	}
-	be := beMap[kubeSvcName]
-	if len(be.HealthChecks) != 1 || be.HealthChecks[0] != hcLink {
-		t.Errorf("unexpected health check in backend service. expected: %s, got: %v", hcLink, be.HealthChecks)
-	}
-	if be.Port != port || be.PortName != portName {
-		t.Errorf("unexpected port and port name, expected: %s/%s, got: %s/%s", portName, port, be.PortName, be.Port)
-	}
-	if len(be.Backends) != 1 || be.Backends[0].Group != igLink {
-		t.Errorf("unexpected backends in backend service. expected one backend for %s, got: %v", igLink, be.Backends)
-	}
-	// TODO(nikhiljindal): Test update existing backend service.
 }
 
 func TestDeleteBackendService(t *testing.T) {
@@ -109,7 +152,7 @@ func TestDeleteBackendService(t *testing.T) {
 			Port: port,
 			Name: portName,
 		},
-	}, []string{igLink}); err != nil {
+	}, []string{igLink}, false /*forceUpdate*/); err != nil {
 		t.Fatalf("expected no error in ensuring backend service, actual: %v", err)
 	}
 	if _, err := bsp.GetGlobalBackendService(beName); err != nil {

--- a/app/kubemci/pkg/gcp/backendservice/fake_backendservicesyncer.go
+++ b/app/kubemci/pkg/gcp/backendservice/fake_backendservicesyncer.go
@@ -15,7 +15,7 @@
 package backendservice
 
 import (
-	"google.golang.org/api/compute/v1"
+	compute "google.golang.org/api/compute/v1"
 	ingressbe "k8s.io/ingress-gce/pkg/backends"
 
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/healthcheck"
@@ -42,7 +42,7 @@ func NewFakeBackendServiceSyncer() BackendServiceSyncerInterface {
 // Ensure this implements BackendServiceSyncerInterface.
 var _ BackendServiceSyncerInterface = &FakeBackendServiceSyncer{}
 
-func (h *FakeBackendServiceSyncer) EnsureBackendService(lbName string, ports []ingressbe.ServicePort, hcMap healthcheck.HealthChecksMap, npMap NamedPortsMap, igLinks []string) (BackendServicesMap, error) {
+func (h *FakeBackendServiceSyncer) EnsureBackendService(lbName string, ports []ingressbe.ServicePort, hcMap healthcheck.HealthChecksMap, npMap NamedPortsMap, igLinks []string, forceUpdate bool) (BackendServicesMap, error) {
 	beMap := BackendServicesMap{}
 	for _, p := range ports {
 		h.EnsuredBackendServices = append(h.EnsuredBackendServices, FakeBackendService{

--- a/app/kubemci/pkg/gcp/backendservice/interfaces.go
+++ b/app/kubemci/pkg/gcp/backendservice/interfaces.go
@@ -15,7 +15,7 @@
 package backendservice
 
 import (
-	"google.golang.org/api/compute/v1"
+	compute "google.golang.org/api/compute/v1"
 	ingressbe "k8s.io/ingress-gce/pkg/backends"
 
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/healthcheck"
@@ -29,10 +29,12 @@ type BackendServicesMap map[string]*compute.BackendService
 
 // BackendServiceSyncerInterface is an interface to manage GCP backend services.
 type BackendServiceSyncerInterface interface {
-	// EnsureBackendService ensures that the required backend services exist.
+	// EnsureBackendService ensures that the required backend services
+	// exist. forceUpdate must be true in order to modify an existing
+	// BackendService.
 	// Returns a map of the ensured backend services.
 	// In case of no error, the map will contain services for all the given array of ports.
-	EnsureBackendService(lbName string, ports []ingressbe.ServicePort, hcMap healthcheck.HealthChecksMap, npMap NamedPortsMap, igLinks []string) (BackendServicesMap, error)
+	EnsureBackendService(lbName string, ports []ingressbe.ServicePort, hcMap healthcheck.HealthChecksMap, npMap NamedPortsMap, igLinks []string, forceUpdate bool) (BackendServicesMap, error)
 	// DeleteBackendServices deletes all backend services that would have been created by EnsureBackendService.
 	DeleteBackendServices(ports []ingressbe.ServicePort) error
 }

--- a/app/kubemci/pkg/gcp/healthcheck/healthchecksyncer.go
+++ b/app/kubemci/pkg/gcp/healthcheck/healthchecksyncer.go
@@ -108,6 +108,11 @@ func (h *HealthCheckSyncer) deleteHealthCheck(port ingressbe.ServicePort) error 
 	return nil
 }
 
+func getJsonIgnoreErr(v interface{}) string {
+	output, _ := json.Marshal(v)
+	return string(output)
+}
+
 func (h *HealthCheckSyncer) ensureHealthCheck(lbName string, port ingressbe.ServicePort, forceUpdate bool) (*compute.HealthCheck, error) {
 	fmt.Println("Ensuring health check for port:", port)
 	desiredHC, err := h.desiredHealthCheck(lbName, port)
@@ -119,11 +124,9 @@ func (h *HealthCheckSyncer) ensureHealthCheck(lbName string, port ingressbe.Serv
 	existingHC, err := h.hcp.GetHealthCheck(name)
 	if err == nil {
 		fmt.Println("Health check", name, "exists already. Checking if it matches our desired health check")
-		jsonExisting, _ := json.Marshal(existingHC)
-		jsonDesired, _ := json.Marshal(desiredHC)
-		glog.V(5).Infof("Existing health check:\n%v\nDesired health check:\n%v\n", string(jsonExisting), string(jsonDesired))
+		glog.V(5).Infof("Existing health check:\n%v\nDesired health check:\n%v\n", getJsonIgnoreErr(existingHC), getJsonIgnoreErr(desiredHC))
 		// Health check with that name exists already. Check if it matches what we want.
-		if healthCheckMatches(&desiredHC, existingHC) {
+		if healthCheckMatches(desiredHC, *existingHC) {
 			// Nothing to do. Desired health check exists already.
 			fmt.Println("Desired health check exists already")
 			return existingHC, nil
@@ -169,7 +172,13 @@ func (h *HealthCheckSyncer) createHealthCheck(desiredHC *compute.HealthCheck) (*
 	return h.hcp.GetHealthCheck(name)
 }
 
-func healthCheckMatches(desiredHC, existingHC *compute.HealthCheck) bool {
+func healthCheckMatches(desiredHC, existingHC compute.HealthCheck) bool {
+	// Clear fields we don't care about to make the printout easier to read.
+	existingHC.CreationTimestamp = ""
+	existingHC.Id = 0
+	existingHC.SelfLink = ""
+	glog.V(5).Infof("\nexisting (minus ignored fields):%v\ndesired:%v", getJsonIgnoreErr(existingHC), getJsonIgnoreErr(desiredHC))
+	// TODO(G-Harmon): We should ignore specific fields instead of checking specific ones.
 	if desiredHC.CheckIntervalSec != existingHC.CheckIntervalSec ||
 		// Ignore creationTimestamp.
 		desiredHC.Description != existingHC.Description ||
@@ -218,6 +227,7 @@ func (h *HealthCheckSyncer) desiredHealthCheck(lbName string, port ingressbe.Ser
 		hc.HttpsHealthCheck = &compute.HTTPSHealthCheck{
 			Port:        port.Port, // TODO(nikhiljindal): Allow customization.
 			RequestPath: "/",       // TODO(nikhiljindal): Allow customization.
+			// TODO(G-Harmon): When HTTPS support is added, we likely need to set ProxyHeader, like HTTP does.
 		}
 		break
 	default:

--- a/app/kubemci/pkg/gcp/healthcheck/healthchecksyncer.go
+++ b/app/kubemci/pkg/gcp/healthcheck/healthchecksyncer.go
@@ -15,6 +15,7 @@
 package healthcheck
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"time"
@@ -118,7 +119,9 @@ func (h *HealthCheckSyncer) ensureHealthCheck(lbName string, port ingressbe.Serv
 	existingHC, err := h.hcp.GetHealthCheck(name)
 	if err == nil {
 		fmt.Println("Health check", name, "exists already. Checking if it matches our desired health check")
-		glog.V(5).Infof("Existing health check: %+v\n, desired health check: %+v\n", existingHC, desiredHC)
+		jsonExisting, _ := json.Marshal(existingHC)
+		jsonDesired, _ := json.Marshal(desiredHC)
+		glog.V(5).Infof("Existing health check:\n%v\nDesired health check:\n%v\n", string(jsonExisting), string(jsonDesired))
 		// Health check with that name exists already. Check if it matches what we want.
 		if healthCheckMatches(&desiredHC, existingHC) {
 			// Nothing to do. Desired health check exists already.
@@ -201,13 +204,14 @@ func (h *HealthCheckSyncer) desiredHealthCheck(lbName string, port ingressbe.Ser
 		// Number of healthchecks to fail before the vm is deemed unhealthy.
 		UnhealthyThreshold: DefaultUnhealthyThreshold,
 		Type:               string(port.Protocol),
-		// TODO: Try Kind: compute#healthCheck
+		Kind:               "compute#healthCheck",
 	}
 	switch port.Protocol {
 	case "HTTP":
 		hc.HttpHealthCheck = &compute.HTTPHealthCheck{
 			Port:        port.Port,
 			RequestPath: "/", // TODO(nikhiljindal): Allow customization.
+			ProxyHeader: "NONE",
 		}
 		break
 	case "HTTPS":

--- a/app/kubemci/pkg/gcp/healthcheck/healthchecksyncer_test.go
+++ b/app/kubemci/pkg/gcp/healthcheck/healthchecksyncer_test.go
@@ -110,21 +110,21 @@ func TestEnsureHealthCheck(t *testing.T) {
 
 func TestHealthCheckMatches(t *testing.T) {
 	var check compute.HealthCheck
-	if !healthCheckMatches(&check, &check) {
+	if !healthCheckMatches(check, check) {
 		t.Errorf("Want healthCheckMatches(c, c) = true. got false.")
 	}
 	check2 := check
 	check2.Description = "foo"
-	if healthCheckMatches(&check, &check2) {
+	if healthCheckMatches(check, check2) {
 		t.Errorf("Want healthCheckMatches(c, c2) = false, c.description differs. got true.")
 	}
 	check.Description = "foo"
-	if !healthCheckMatches(&check, &check2) {
+	if !healthCheckMatches(check, check2) {
 		t.Errorf("Health checks should be identical again c:%v, c2:%v", check, check2)
 	}
 	// CreationTimestamp should be ignored.
 	check2.CreationTimestamp = "1234"
-	if !healthCheckMatches(&check, &check2) {
+	if !healthCheckMatches(check, check2) {
 		t.Errorf("Health checks only differ in creation timestamp, watch Matches(c, c2)=true, got false")
 	}
 }

--- a/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
+++ b/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
@@ -128,7 +128,7 @@ func (l *LoadBalancerSyncer) CreateLoadBalancer(ing *v1beta1.Ingress, forceUpdat
 		igsForBE = append(igsForBE, igs[k]...)
 	}
 	// Create backend service. This should always be called after the health check since backend service needs to point to the health check.
-	backendServices, beErr := l.bss.EnsureBackendService(l.lbName, ports, healthChecks, namedPorts, igsForBE)
+	backendServices, beErr := l.bss.EnsureBackendService(l.lbName, ports, healthChecks, namedPorts, igsForBE, forceUpdate)
 	if beErr != nil {
 		// Aggregate errors and return all at the end.
 		err = multierror.Append(err, beErr)
@@ -314,11 +314,13 @@ func (l *LoadBalancerSyncer) getNamedPorts(igUrl string) (backendservice.NamedPo
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println("Fetched instance group:", zone, "/", name, "got named ports:", ig.NamedPorts)
+	fmt.Printf("Fetched instance group: %s/%s got named ports: ", zone, name)
 	namedPorts := backendservice.NamedPortsMap{}
 	for _, np := range ig.NamedPorts {
+		fmt.Printf("port: %v ", np)
 		namedPorts[np.Port] = np
 	}
+	fmt.Printf("\n")
 	return namedPorts, nil
 }
 func (l *LoadBalancerSyncer) ingToNodePorts(ing *v1beta1.Ingress, client kubeclient.Interface) []ingressbe.ServicePort {


### PR DESCRIPTION
We only want to modify an existing BackendService if the user supplies the --force flag.

Note: I still need to debug the healthcheck comparison handling, before I can properly (manually) test this.

Reviewers: @nikhiljindal @csbell @madhusudancs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/27)
<!-- Reviewable:end -->
