### PR TITLE
Check in myzone example to the examples directory.

### DIFF
--- a/examples/zone-printer/app/nginx-dep.yaml
+++ b/examples/zone-printer/app/nginx-dep.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+    type: demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: frontend
+        ports:
+          - containerPort: 80
+        volumeMounts:
+        - name: html-dir
+          mountPath: /usr/share/nginx/html
+      - image: busybox
+        name: zone-fetcher
+        command:
+          - "/bin/sh"
+          - "-c"
+          - "/zonefetch/zonefetch.sh"
+        volumeMounts:
+        - name: zone-fetch
+          mountPath: /zonefetch
+        - name: html-dir
+          mountPath: /usr/share/nginx/html
+      volumes:
+        - name: zone-fetch
+          configMap:
+            defaultMode: 0777
+            name: zone-fetch
+        - name: html-dir
+          emptyDir:
+            medium: ""

--- a/examples/zone-printer/app/nginx-svc.yaml
+++ b/examples/zone-printer/app/nginx-svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+    name: http
+    nodePort: 30061
+  selector:
+    app: nginx
+  type: NodePort

--- a/examples/zone-printer/app/zonefetch.yaml
+++ b/examples/zone-printer/app/zonefetch.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zone-fetch
+data:
+  zonefetch.sh: |-
+    #!/bin/sh
+    
+    wget -q --header "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/zone"
+    
+    zone=$(cat zone | sed -e "s#^projects/[[:digit:]]\+/zones/\(.*\)#\1#")
+    
+    cat <<EOF >/usr/share/nginx/html/index.html
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <title>Welcome to the global site!</title>
+    </head>
+    <body>
+    <h1>Welcome to the global site! You are being served from ${zone}</h1>
+    <p>Congratulations!</p>
+    EOF
+
+    while true; do sleep 100d; done

--- a/examples/zone-printer/ingress/nginx.yaml
+++ b/examples/zone-printer/ingress/nginx.yaml
@@ -1,0 +1,11 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: nginx
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: ip-for-kubemci
+    kubernetes.io/ingress.class: gce-multi-cluster
+spec:
+  backend:
+    serviceName: nginx
+    servicePort: 80


### PR DESCRIPTION
README to follow. This example contains an application that fetches the GCP zone the cluster is running in and serves that information on the paths `/`  or `/index.path`  via an nginx server.