### PR TITLE
Make the kubeconfig flag required.

### DIFF
--- a/app/kubemci/cmd/create.go
+++ b/app/kubemci/cmd/create.go
@@ -113,7 +113,7 @@ func NewCmdCreate(out, err io.Writer) *cobra.Command {
 
 func addCreateFlags(cmd *cobra.Command, options *CreateOptions) error {
 	cmd.Flags().StringVarP(&options.IngressFilename, "ingress", "i", options.IngressFilename, "[required] filename containing ingress spec")
-	cmd.Flags().StringVarP(&options.KubeconfigFilename, "kubeconfig", "k", options.KubeconfigFilename, "[optional] path to kubeconfig file")
+	cmd.Flags().StringVarP(&options.KubeconfigFilename, "kubeconfig", "k", options.KubeconfigFilename, "[required] path to kubeconfig file")
 	cmd.Flags().StringSliceVar(&options.KubeContexts, "kubecontexts", options.KubeContexts, "[optional] contexts in the kubeconfig file to install the ingress into")
 	// TODO(nikhiljindal): Add a short flag "-p" if it seems useful.
 	cmd.Flags().StringVarP(&options.GCPProject, "gcp-project", "", options.GCPProject, "[required] name of the gcp project")
@@ -133,6 +133,9 @@ func validateCreateArgs(options *CreateOptions, args []string) error {
 	}
 	if options.GCPProject == "" {
 		return fmt.Errorf("unexpected missing argument gcp-project.")
+	}
+	if options.KubeconfigFilename == "" {
+		return fmt.Errorf("unexpected missing argument kubeconfig.")
 	}
 	return nil
 }

--- a/app/kubemci/cmd/create_test.go
+++ b/app/kubemci/cmd/create_test.go
@@ -69,8 +69,9 @@ func TestValidateCreateArgs(t *testing.T) {
 
 	// validateCreateArgs should return an error with missing load balancer name.
 	options = CreateOptions{
-		IngressFilename: "ingress.yaml",
-		GCPProject:      "gcp-project",
+		IngressFilename:    "ingress.yaml",
+		GCPProject:         "gcp-project",
+		KubeconfigFilename: "kubeconfig",
 	}
 	if err := validateCreateArgs(&options, []string{}); err == nil {
 		t.Errorf("Expected error for missing load balancer name")
@@ -78,7 +79,8 @@ func TestValidateCreateArgs(t *testing.T) {
 
 	// validateCreateArgs should return an error with missing ingress.
 	options = CreateOptions{
-		GCPProject: "gcp-project",
+		GCPProject:         "gcp-project",
+		KubeconfigFilename: "kubeconfig",
 	}
 	if err := validateCreateArgs(&options, []string{"lbname"}); err == nil {
 		t.Errorf("Expected error for missing ingress")
@@ -86,16 +88,27 @@ func TestValidateCreateArgs(t *testing.T) {
 
 	// validateCreateArgs should return an error with missing gcp project.
 	options = CreateOptions{
-		IngressFilename: "ingress.yaml",
+		IngressFilename:    "ingress.yaml",
+		KubeconfigFilename: "kubeconfig",
 	}
 	if err := validateCreateArgs(&options, []string{"lbname"}); err == nil {
 		t.Errorf("Expected error for missing gcp project")
 	}
 
-	// validateCreateArgs should succeed when all arguments are passed as expected.
+	// validateCreateArgs should return an error with missing kubeconfig.
 	options = CreateOptions{
 		IngressFilename: "ingress.yaml",
 		GCPProject:      "gcp-project",
+	}
+	if err := validateCreateArgs(&options, []string{"lbname"}); err == nil {
+		t.Errorf("Expected error for missing kubeconfig")
+	}
+
+	// validateCreateArgs should succeed when all arguments are passed as expected.
+	options = CreateOptions{
+		IngressFilename:    "ingress.yaml",
+		GCPProject:         "gcp-project",
+		KubeconfigFilename: "kubeconfig",
 	}
 	if err := validateCreateArgs(&options, []string{"lbname"}); err != nil {
 		t.Errorf("unexpected error from validateCreateArgs: %s", err)

--- a/app/kubemci/cmd/delete.go
+++ b/app/kubemci/cmd/delete.go
@@ -78,7 +78,7 @@ func NewCmdDelete(out, err io.Writer) *cobra.Command {
 
 func addDeleteFlags(cmd *cobra.Command, options *DeleteOptions) error {
 	cmd.Flags().StringVarP(&options.IngressFilename, "ingress", "i", options.IngressFilename, "[required] filename containing ingress spec")
-	cmd.Flags().StringVarP(&options.KubeconfigFilename, "kubeconfig", "k", options.KubeconfigFilename, "[optional] path to kubeconfig file")
+	cmd.Flags().StringVarP(&options.KubeconfigFilename, "kubeconfig", "k", options.KubeconfigFilename, "[required] path to kubeconfig file")
 	cmd.Flags().StringSliceVar(&options.KubeContexts, "kubecontexts", options.KubeContexts, "[optional] contexts in the kubeconfig file to delete the ingress from")
 	// TODO(nikhiljindal): Add a short flag "-p" if it seems useful.
 	cmd.Flags().StringVarP(&options.GCPProject, "gcp-project", "", options.GCPProject, "[required] name of the gcp project")
@@ -96,6 +96,9 @@ func validateDeleteArgs(options *DeleteOptions, args []string) error {
 	}
 	if options.GCPProject == "" {
 		return fmt.Errorf("unexpected missing argument gcp-project.")
+	}
+	if options.KubeconfigFilename == "" {
+		return fmt.Errorf("unexpected missing argument kubeconfig.")
 	}
 	return nil
 }

--- a/app/kubemci/cmd/delete_test.go
+++ b/app/kubemci/cmd/delete_test.go
@@ -33,8 +33,9 @@ func TestValidateDeleteArgs(t *testing.T) {
 
 	// validateDeleteArgs should return an error with missing load balancer name.
 	options = DeleteOptions{
-		IngressFilename: "ingress.yaml",
-		GCPProject:      "gcp-project",
+		IngressFilename:    "ingress.yaml",
+		GCPProject:         "gcp-project",
+		KubeconfigFilename: "kubeconfig",
 	}
 	if err := validateDeleteArgs(&options, []string{}); err == nil {
 		t.Errorf("Expected error for missing load balancer name")
@@ -42,7 +43,8 @@ func TestValidateDeleteArgs(t *testing.T) {
 
 	// validateDeleteArgs should return an error with missing ingress.
 	options = DeleteOptions{
-		GCPProject: "gcp-project",
+		GCPProject:         "gcp-project",
+		KubeconfigFilename: "kubeconfig",
 	}
 	if err := validateDeleteArgs(&options, []string{"lbname"}); err == nil {
 		t.Errorf("Expected error for missing ingress")
@@ -50,16 +52,27 @@ func TestValidateDeleteArgs(t *testing.T) {
 
 	// validateDeleteArgs should return an error with missing gcp project.
 	options = DeleteOptions{
-		IngressFilename: "ingress.yaml",
+		IngressFilename:    "ingress.yaml",
+		KubeconfigFilename: "kubeconfig",
 	}
 	if err := validateDeleteArgs(&options, []string{"lbname"}); err == nil {
 		t.Errorf("Expected error for missing gcp project")
 	}
 
-	// validateDeleteArgs should succeed when all arguments are passed as expected.
+	// validateDeleteArgs should return an error with missing kubeconfig.
 	options = DeleteOptions{
 		IngressFilename: "ingress.yaml",
 		GCPProject:      "gcp-project",
+	}
+	if err := validateDeleteArgs(&options, []string{"lbname"}); err == nil {
+		t.Errorf("Expected error for missing kubeconfig")
+	}
+
+	// validateDeleteArgs should succeed when all arguments are passed as expected.
+	options = DeleteOptions{
+		IngressFilename:    "ingress.yaml",
+		GCPProject:         "gcp-project",
+		KubeconfigFilename: "kubeconfig",
 	}
 	if err := validateDeleteArgs(&options, []string{"lbname"}); err != nil {
 		t.Errorf("unexpected error from validateDeleteArgs: %s", err)


### PR DESCRIPTION
Just warns for now. We could add a "Press a key to continue..." prompt if we think this is important enough.