### PR TITLE
Add a flag to kubemci that takes a list of contexts.

### DIFF
--- a/app/kubemci/cmd/create_test.go
+++ b/app/kubemci/cmd/create_test.go
@@ -113,7 +113,7 @@ func TestCreateIngress(t *testing.T) {
 	}
 
 	runFn := func() ([]string, map[string]kubeclient.Interface, error) {
-		return createIngress("kubeconfig", "../../../testdata/ingress.yaml")
+		return createIngress("kubeconfig", []string{}, "../../../testdata/ingress.yaml")
 	}
 	expectedCommands := []ExpectedCommand{
 		{

--- a/app/kubemci/cmd/delete.go
+++ b/app/kubemci/cmd/delete.go
@@ -79,7 +79,7 @@ func NewCmdDelete(out, err io.Writer) *cobra.Command {
 func addDeleteFlags(cmd *cobra.Command, options *DeleteOptions) error {
 	cmd.Flags().StringVarP(&options.IngressFilename, "ingress", "i", options.IngressFilename, "filename containing ingress spec")
 	cmd.Flags().StringVarP(&options.KubeconfigFilename, "kubeconfig", "k", options.KubeconfigFilename, "path to kubeconfig file")
-	cmd.Flags().StringSliceVar(&options.KubeContexts, "kubecontexts", options.KubeContexts, "contexts in the kubeconfig file to install the ingress into")
+	cmd.Flags().StringSliceVar(&options.KubeContexts, "kubecontexts", options.KubeContexts, "contexts in the kubeconfig file to delete the ingress from")
 	// TODO(nikhiljindal): Add a short flag "-p" if it seems useful.
 	cmd.Flags().StringVarP(&options.GCPProject, "gcp-project", "", options.GCPProject, "name of the gcp project")
 	// TODO Add a verbose flag that turns on glog logging.

--- a/app/kubemci/cmd/delete_test.go
+++ b/app/kubemci/cmd/delete_test.go
@@ -72,7 +72,7 @@ func TestDeleteIngress(t *testing.T) {
 	})
 
 	runFn := func() ([]string, map[string]kubeclient.Interface, error) {
-		return []string{}, nil, deleteIngress("kubeconfig", "../../../testdata/ingress.yaml")
+		return []string{}, nil, deleteIngress("kubeconfig", []string{}, "../../../testdata/ingress.yaml")
 	}
 	expectedCommands := []ExpectedCommand{
 		{


### PR DESCRIPTION
I considered adding tests for this, but the tests would have been checking that the end of the kubectl command had these string values, which didn't seem like a valuable test. I can add those tests if you want.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/30)
<!-- Reviewable:end -->
