### PR TITLE
Adding code to create firewall rules

### DIFF
--- a/app/kubemci/cmd/create.go
+++ b/app/kubemci/cmd/create.go
@@ -151,7 +151,10 @@ func runCreate(options *CreateOptions, args []string) error {
 		return err
 	}
 
-	lbs := gcplb.NewLoadBalancerSyncer(options.LBName, clients, cloudInterface)
+	lbs, err := gcplb.NewLoadBalancerSyncer(options.LBName, clients, cloudInterface, options.GCPProject)
+	if err != nil {
+		return err
+	}
 	return lbs.CreateLoadBalancer(&ing, options.ForceUpdate, clusters)
 }
 

--- a/app/kubemci/cmd/delete.go
+++ b/app/kubemci/cmd/delete.go
@@ -121,7 +121,10 @@ func runDelete(options *DeleteOptions, args []string) error {
 
 	// DeleteLoadBalancer uses a random client from the given clientset map,
 	// so it is fine to pass a map with just one client.
-	lbs := gcplb.NewLoadBalancerSyncer(options.LBName, map[string]kubeclient.Interface{"": clientset}, cloudInterface)
+	lbs, err := gcplb.NewLoadBalancerSyncer(options.LBName, map[string]kubeclient.Interface{"": clientset}, cloudInterface, options.GCPProject)
+	if err != nil {
+		return err
+	}
 	if delErr := lbs.DeleteLoadBalancer(&ing); delErr != nil {
 		err = multierror.Append(err, delErr)
 	}

--- a/app/kubemci/cmd/getstatus.go
+++ b/app/kubemci/cmd/getstatus.go
@@ -90,7 +90,10 @@ func runGetStatus(options *GetStatusOptions, args []string) error {
 		return fmt.Errorf("error in creating cloud interface: %s", err)
 	}
 
-	lbs := gcplb.NewLoadBalancerSyncer(options.LBName, nil /* clientset */, cloudInterface)
+	lbs, err := gcplb.NewLoadBalancerSyncer(options.LBName, nil /* clientset */, cloudInterface, options.GCPProject)
+	if err != nil {
+		return err
+	}
 	status, err := lbs.PrintStatus()
 	if err != nil {
 		return err

--- a/app/kubemci/pkg/gcp/backendservice/backendservicesyncer.go
+++ b/app/kubemci/pkg/gcp/backendservice/backendservicesyncer.go
@@ -122,14 +122,11 @@ func (b *BackendServiceSyncer) ensureBackendService(lbName string, port ingressb
 			return existingBE, nil
 		}
 		// TODO (nikhiljindal): Require explicit permission from user before doing this.
-		fmt.Println("Updating existing backend service", name, "to match the desired state")
 		return b.updateBackendService(desiredBE)
 	}
 	glog.V(5).Infof("Got error %s while trying to get existing backend service %s", err, name)
 	// TODO(nikhiljindal): Handle non NotFound errors. We should create only if the error is NotFound.
 	// Create the backend service.
-	fmt.Println("Creating backend service", name)
-	glog.V(5).Infof("Creating backend service %v", *desiredBE)
 	return b.createBackendService(desiredBE)
 }
 

--- a/app/kubemci/pkg/gcp/firewallrule/fake_firewallrulesyncer.go
+++ b/app/kubemci/pkg/gcp/firewallrule/fake_firewallrulesyncer.go
@@ -1,0 +1,52 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firewallrule
+
+import (
+	ingressbe "k8s.io/ingress-gce/pkg/backends"
+)
+
+type FakeFirewallRule struct {
+	LBName  string
+	Ports   []ingressbe.ServicePort
+	IGLinks map[string][]string
+}
+
+type FakeFirewallRuleSyncer struct {
+	// List of firewall rules that this has been asked to ensure.
+	EnsuredFirewallRules []FakeFirewallRule
+}
+
+// Fake firewall rule syncer to be used for tests.
+func NewFakeFirewallRuleSyncer() FirewallRuleSyncerInterface {
+	return &FakeFirewallRuleSyncer{}
+}
+
+// Ensure this implements FirewallRuleSyncerInterface.
+var _ FirewallRuleSyncerInterface = &FakeFirewallRuleSyncer{}
+
+func (h *FakeFirewallRuleSyncer) EnsureFirewallRule(lbName string, ports []ingressbe.ServicePort, igLinks map[string][]string) error {
+	h.EnsuredFirewallRules = append(h.EnsuredFirewallRules, FakeFirewallRule{
+		LBName:  lbName,
+		Ports:   ports,
+		IGLinks: igLinks,
+	})
+	return nil
+}
+
+func (h *FakeFirewallRuleSyncer) DeleteFirewallRules() error {
+	h.EnsuredFirewallRules = nil
+	return nil
+}

--- a/app/kubemci/pkg/gcp/firewallrule/firewallrulesyncer.go
+++ b/app/kubemci/pkg/gcp/firewallrule/firewallrulesyncer.go
@@ -1,0 +1,180 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firewallrule
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/golang/glog"
+	"google.golang.org/api/compute/v1"
+	ingressbe "k8s.io/ingress-gce/pkg/backends"
+	ingressfw "k8s.io/ingress-gce/pkg/firewalls"
+
+	utilsnamer "github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/namer"
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/networktags"
+)
+
+// Src ranges from which the GCE L7 performs health checks.
+var l7SrcRanges = []string{"130.211.0.0/22", "35.191.0.0/16"}
+
+// FirewallRuleSyncer manages GCP firewall rules for multicluster GCP L7 load balancers.
+type FirewallRuleSyncer struct {
+	namer *utilsnamer.Namer
+	// Firewall rules provider to call GCE APIs to manipulate firewall rules.
+	fwp ingressfw.Firewall
+	// NetworkTagsGetterInterface to fetch network tags from instances.
+	ntg networktags.NetworkTagsGetterInterface
+}
+
+func NewFirewallRuleSyncer(namer *utilsnamer.Namer, fwp ingressfw.Firewall, ntg networktags.NetworkTagsGetterInterface) FirewallRuleSyncerInterface {
+	return &FirewallRuleSyncer{
+		namer: namer,
+		fwp:   fwp,
+		ntg:   ntg,
+	}
+}
+
+// Ensure this implements FirewallRuleSyncerInterface.
+var _ FirewallRuleSyncerInterface = &FirewallRuleSyncer{}
+
+// EnsureFirewallRule ensures that the required firewall rules exist for the given ports.
+// Does nothing if they exist already, else creates new ones.
+func (s *FirewallRuleSyncer) EnsureFirewallRule(lbName string, ports []ingressbe.ServicePort, igLinks map[string][]string) error {
+	fmt.Println("Ensuring firewall rule")
+	glog.V(5).Infof("Received ports: %v", ports)
+	glog.V(5).Infof("Received instance groups: %v", igLinks)
+	err := s.ensureFirewallRule(lbName, ports, igLinks)
+	if err != nil {
+		return fmt.Errorf("Error %s in ensuring firewall rule", err)
+	}
+	return nil
+}
+
+func (s *FirewallRuleSyncer) DeleteFirewallRules() error {
+	name := s.namer.FirewallRuleName()
+	fmt.Println("Deleting firewall rule", name)
+	if err := s.fwp.DeleteFirewall(name); err != nil {
+		fmt.Printf("Error in deleting firewall rule %s: %s", name, err)
+		return err
+	}
+	fmt.Println("firewall rule", name, "deleted successfully")
+	return nil
+}
+
+// ensureFirewallRule ensures that the required firewall rule exists for the given ports.
+// Does nothing if it exists already, else creates a new one.
+func (s *FirewallRuleSyncer) ensureFirewallRule(lbName string, ports []ingressbe.ServicePort, igLinks map[string][]string) error {
+	desiredFW, err := s.desiredFirewallRule(lbName, ports, igLinks)
+	if err != nil {
+		return err
+	}
+	name := desiredFW.Name
+	// Check if firewall rule already exists.
+	existingFW, err := s.fwp.GetFirewall(name)
+	if err == nil {
+		fmt.Println("Firewall rule", name, "exists already. Checking if it matches our desired firewall rule")
+		glog.V(5).Infof("Existing firewall rule: %v\n, desired firewall rule: %v", existingFW, *desiredFW)
+		// Firewall rule with that name exists already. Check if it matches what we want.
+		if firewallRuleMatches(desiredFW, existingFW) {
+			// Nothing to do. Desired firewall rule exists already.
+			fmt.Println("Desired firewall rule exists already")
+			return nil
+		}
+		// TODO (nikhiljindal): Require explicit permission from user before doing this.
+		return s.updateFirewallRule(desiredFW)
+	}
+	glog.V(5).Infof("Got error %s while trying to get existing firewall rule %s", err, name)
+	// TODO(nikhiljindal): Handle non NotFound errors. We should create only if the error is NotFound.
+	// Create the firewall rule.
+	return s.createFirewallRule(desiredFW)
+}
+
+// updateFirewallRule updates the firewall rule and returns the updated firewall rule.
+func (s *FirewallRuleSyncer) updateFirewallRule(desiredFR *compute.Firewall) error {
+	name := desiredFR.Name
+	fmt.Println("Updating existing firewall rule", name, "to match the desired state")
+	err := s.fwp.UpdateFirewall(desiredFR)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Firewall rule", name, "updated successfully")
+	return nil
+}
+
+// createFirewallRule creates the firewall rule and returns the created firewall rule.
+func (s *FirewallRuleSyncer) createFirewallRule(desiredFR *compute.Firewall) error {
+	name := desiredFR.Name
+	fmt.Println("Creating firewall rule", name)
+	glog.V(5).Infof("Creating firewall rule %v", desiredFR)
+	err := s.fwp.CreateFirewall(desiredFR)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Firewall rule", name, "created successfully")
+	return nil
+}
+
+func firewallRuleMatches(desiredFR, existingFR *compute.Firewall) bool {
+	// TODO(nikhiljindal): Add proper logic to figure out if the 2 firewall rules match.
+	// Need to add the --force flag for user to consent overwriting before this method can be updated to return false.
+	// Also need to take special care of target tags. There can be multiple target tags, all of which can be "correct".
+	return true
+}
+
+func (s *FirewallRuleSyncer) desiredFirewallRule(lbName string, ports []ingressbe.ServicePort, igLinks map[string][]string) (*compute.Firewall, error) {
+	// Compute the desired firewall rule.
+	targetTags, err := s.getTargetTags(igLinks)
+	if err != nil {
+		return nil, err
+	}
+	fwPorts := make([]string, len(ports))
+	for i := range ports {
+		fwPorts[i] = strconv.Itoa(int(ports[i].Port))
+	}
+	// Sort the ports and tags to have a deterministic order.
+	sort.Strings(fwPorts)
+	sort.Strings(targetTags)
+	return &compute.Firewall{
+		Name:         s.namer.FirewallRuleName(),
+		Description:  fmt.Sprintf("Firewall rule for kubernetes multicluster loadbalancer %s", lbName),
+		SourceRanges: l7SrcRanges,
+		Allowed: []*compute.FirewallAllowed{
+			{
+				IPProtocol: "tcp",
+				Ports:      fwPorts,
+			},
+		},
+		TargetTags: targetTags,
+		// TODO(nikhiljindal): Set the `Network` field for non-default networks.
+	}, nil
+}
+
+func (s *FirewallRuleSyncer) getTargetTags(igLinks map[string][]string) ([]string, error) {
+	// We assume that all instances in a cluster have the same target tags.
+	// This is true for default GKE and GCE clusters (brought up using kube-up).
+	// So we return the first target tag from the first instance in first instance group of each cluster.
+	// TODO(nikhiljindal): Make this more resilient. If we fail to fetch tag from one instance group, try the next.
+	var tags []string
+	for _, v := range igLinks {
+		items, err := s.ntg.GetNetworkTags(v[0])
+		if err != nil {
+			return nil, err
+		}
+		tags = append(tags, items[0])
+	}
+	return tags, nil
+}

--- a/app/kubemci/pkg/gcp/firewallrule/firewallrulesyncer_test.go
+++ b/app/kubemci/pkg/gcp/firewallrule/firewallrulesyncer_test.go
@@ -1,0 +1,113 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firewallrule
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	ingressbe "k8s.io/ingress-gce/pkg/backends"
+	ingressfw "k8s.io/ingress-gce/pkg/firewalls"
+
+	utilsnamer "github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/namer"
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/networktags"
+)
+
+func TestEnsureFirewallRule(t *testing.T) {
+	lbName := "lb-name"
+	port := int64(32211)
+	kubeSvcName := "svc-name"
+	igLink := "https://www.googleapis.com/compute/v1/projects/abc/zones/def/instanceGroups/ig1"
+	networkTag := "fake-network-tag"
+	// Should create the firewall rule as expected.
+	fwp := ingressfw.NewFakeFirewallsProvider(false /* xpn */, false /* read only */)
+	ntg := networktags.NewFakeNetworkTagsGetter([]string{networkTag})
+	namer := utilsnamer.NewNamer("mci1", lbName)
+	fwName := namer.FirewallRuleName()
+	fws := NewFirewallRuleSyncer(namer, fwp, ntg)
+	// GET should return NotFound.
+	if _, err := fwp.GetFirewall(fwName); err == nil {
+		t.Fatalf("expected NotFound error, actual: nil")
+	}
+	err := fws.EnsureFirewallRule(lbName, []ingressbe.ServicePort{
+		{
+			Port:     port,
+			Protocol: "HTTP",
+			SvcName:  types.NamespacedName{Name: kubeSvcName},
+		},
+	}, map[string][]string{"cluster1": []string{igLink}})
+	if err != nil {
+		t.Fatalf("expected no error in ensuring firewall rule, actual: %v", err)
+	}
+	// Verify that the created firewall rule is as expected.
+	fw, err := fwp.GetFirewall(fwName)
+	if err != nil {
+		t.Fatalf("expected nil error, actual: %v", err)
+	}
+	if !reflect.DeepEqual(fw.SourceRanges, l7SrcRanges) {
+		t.Errorf("unexpected source ranges, expected: %s, got: %s", l7SrcRanges, fw.SourceRanges)
+	}
+	expectedPort := strconv.Itoa(int(port))
+	if len(fw.Allowed) != 1 || len(fw.Allowed[0].Ports) != 1 || fw.Allowed[0].Ports[0] != expectedPort {
+		t.Errorf("unexpected allowed, expected only one port item with port %s, got: %v", expectedPort, fw.Allowed)
+	}
+	if len(fw.TargetTags) != 1 || fw.TargetTags[0] != networkTag {
+		t.Errorf("unexpected target tags in firewall rule, expected only on item for %s, got: %v", networkTag, fw.TargetTags)
+	}
+	// TODO(nikhiljindal): Test update existing firewall rule.
+}
+
+func TestDeleteFirewallRule(t *testing.T) {
+	lbName := "lb-name"
+	port := int64(32211)
+	kubeSvcName := "svc-name"
+	igLink := "https://www.googleapis.com/compute/v1/projects/abc/zones/def/instanceGroups/ig1"
+	networkTag := "fake-network-tag"
+	// Should create the firewall rule as expected.
+	fwp := ingressfw.NewFakeFirewallsProvider(false /* xpn */, false /* read only */)
+	ntg := networktags.NewFakeNetworkTagsGetter([]string{networkTag})
+	namer := utilsnamer.NewNamer("mci1", lbName)
+	fwName := namer.FirewallRuleName()
+	fws := NewFirewallRuleSyncer(namer, fwp, ntg)
+	// GET should return NotFound.
+	if _, err := fwp.GetFirewall(fwName); err == nil {
+		t.Fatalf("expected NotFound error, actual: nil")
+	}
+	err := fws.EnsureFirewallRule(lbName, []ingressbe.ServicePort{
+		{
+			Port:     port,
+			Protocol: "HTTP",
+			SvcName:  types.NamespacedName{Name: kubeSvcName},
+		},
+	}, map[string][]string{"cluster1": []string{igLink}})
+	if err != nil {
+		t.Fatalf("expected no error in ensuring firewall rule, actual: %v", err)
+	}
+	// Verify that the created firewall rule is as expected.
+	_, err = fwp.GetFirewall(fwName)
+	if err != nil {
+		t.Fatalf("expected nil error, actual: %v", err)
+	}
+
+	// Verify that GET fails after DELETE.
+	if err := fws.DeleteFirewallRules(); err != nil {
+		t.Fatalf("unexpected error in deleting firewall rules: %s", err)
+	}
+	if _, err := fwp.GetFirewall(fwName); err == nil {
+		t.Errorf("unexpected nil error, expected NotFound")
+	}
+}

--- a/app/kubemci/pkg/gcp/firewallrule/interfaces.go
+++ b/app/kubemci/pkg/gcp/firewallrule/interfaces.go
@@ -1,0 +1,27 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firewallrule
+
+import (
+	ingressbe "k8s.io/ingress-gce/pkg/backends"
+)
+
+// FirewallRuleSyncerInterface is an interface to manage GCP firewall rules.
+type FirewallRuleSyncerInterface interface {
+	// EnsureFirewallRule ensures that the required firewall rules exist.
+	EnsureFirewallRule(lbName string, ports []ingressbe.ServicePort, igLinks map[string][]string) error
+	// DeleteFirewallRules deletes all firewall rules that would have been created by EnsureFirewallRule.
+	DeleteFirewallRules() error
+}

--- a/app/kubemci/pkg/gcp/namer/namer.go
+++ b/app/kubemci/pkg/gcp/namer/namer.go
@@ -26,6 +26,7 @@ const (
 	targetHttpsProxyPrefix    = "tps"
 	httpForwardingRulePrefix  = "fw"
 	httpsForwardingRulePrefix = "fws"
+	firewallRulePrefix        = "fr"
 
 	// A delimiter used for clarity in naming GCE resources.
 	lbNameDelimiter = "--"
@@ -85,6 +86,10 @@ func (n *Namer) HttpsForwardingRuleName() string {
 
 func (n *Namer) HttpForwardingRuleName() string {
 	return n.decorateName(fmt.Sprintf("%v-%v", n.prefix, httpForwardingRulePrefix))
+}
+
+func (n *Namer) FirewallRuleName() string {
+	return n.decorateName(fmt.Sprintf("%v-%v", n.prefix, firewallRulePrefix))
 }
 
 func (n *Namer) decorateName(name string) string {

--- a/app/kubemci/pkg/gcp/networktags/fake_networktags.go
+++ b/app/kubemci/pkg/gcp/networktags/fake_networktags.go
@@ -1,0 +1,33 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networktags
+
+func NewFakeNetworkTagsGetter(tags []string) NetworkTagsGetterInterface {
+	return &FakeNetworkTagsGetter{
+		tags: tags,
+	}
+}
+
+// FakeNetworkTagsGetter to be used for tests.
+type FakeNetworkTagsGetter struct {
+	tags []string
+}
+
+// Ensure this implements NetworkTagsGetterInterface
+var _ NetworkTagsGetterInterface = &FakeNetworkTagsGetter{}
+
+func (g *FakeNetworkTagsGetter) GetNetworkTags(igUrl string) ([]string, error) {
+	return g.tags, nil
+}

--- a/app/kubemci/pkg/gcp/networktags/interfaces.go
+++ b/app/kubemci/pkg/gcp/networktags/interfaces.go
@@ -1,0 +1,22 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package networktags
+
+// Interface to fetch network tags from GCE instances.
+// TODO(nikhiljindal): Move this logic to gce cloudprovider in kubernetes/kubernetes.
+type NetworkTagsGetterInterface interface {
+	// Returns all network tags of an instance in the given instance group.
+	GetNetworkTags(igUrl string) ([]string, error)
+}

--- a/app/kubemci/pkg/gcp/networktags/networktags.go
+++ b/app/kubemci/pkg/gcp/networktags/networktags.go
@@ -1,0 +1,79 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networktags
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/compute/v1"
+
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/utils"
+)
+
+func NewNetworkTagsGetter(projectID string) (NetworkTagsGetterInterface, error) {
+	ctx := context.Background()
+	client, err := google.DefaultClient(ctx, compute.CloudPlatformScope)
+	if err != nil {
+		return nil, fmt.Errorf("error in instantiating GCP client: %s", err)
+	}
+	return &NetworkTagsGetter{
+		client:       client,
+		gcpProjectID: projectID,
+	}, nil
+}
+
+type NetworkTagsGetter struct {
+	gcpProjectID string
+	client       *http.Client
+}
+
+// Ensure this implements NetworkTagsGetterInterface
+var _ NetworkTagsGetterInterface = &NetworkTagsGetter{}
+
+func (g *NetworkTagsGetter) GetNetworkTags(igUrl string) ([]string, error) {
+	service, err := compute.New(g.client)
+	if err != nil {
+		return nil, fmt.Errorf("error in instantiating GCP client: %s", err)
+	}
+	// First get an instance from this instance group.
+	igZone, igName, err := utils.GetZoneAndNameFromIGUrl(igUrl)
+	if err != nil {
+		return nil, err
+	}
+	// TODO: Handle paging if we care about more than one instance.
+	res, err := service.InstanceGroups.ListInstances(g.gcpProjectID, igZone, igName, &compute.InstanceGroupsListInstancesRequest{}).Do()
+	if err != nil {
+		return nil, fmt.Errorf("error in fetching instances in instance group %s/%s: %s", igZone, igName, err)
+	}
+	if len(res.Items) == 0 {
+		return nil, fmt.Errorf("no instance found in instance group %s/%s", igZone, igName)
+	}
+	// Fetch the instance to get its network tags.
+	iZone, iName, err := utils.GetZoneAndNameFromInstanceUrl(res.Items[0].Instance)
+	if err != nil {
+		return nil, fmt.Errorf("error in parsing an instance Url %s: %s", res.Items[0].Instance, err)
+	}
+	instance, err := service.Instances.Get(g.gcpProjectID, iZone, iName).Do()
+	if err != nil {
+		return nil, fmt.Errorf("error in fetching instance %s/%s: %s", iZone, iName, err)
+	}
+	if len(instance.Tags.Items) == 0 {
+		return nil, fmt.Errorf("no network tag found on instance %s/%s", iZone, iName)
+	}
+	return instance.Tags.Items, nil
+}

--- a/app/kubemci/pkg/gcp/utils/utils.go
+++ b/app/kubemci/pkg/gcp/utils/utils.go
@@ -1,0 +1,63 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Returns the zone and name of the instance group from a GCP instance group URL.
+func GetZoneAndNameFromIGUrl(igUrl string) (string, string, error) {
+	// Split the string by "/instanceGroups/".
+	components := strings.Split(igUrl, "/instanceGroups/")
+	if len(components) != 2 {
+		return "", "", fmt.Errorf("error in parsing instance groups URL: %s, expected it to contain /instanceGroups", igUrl)
+	}
+	zoneUrl := components[0]
+	name := components[1]
+	zone, err := GetNameFromUrl(zoneUrl)
+	if err != nil {
+		return "", "", fmt.Errorf("error in parsing zone name from its url: %s", err)
+	}
+	return zone, name, nil
+}
+
+// Returns the zone and name of the instance from a GCP instance URL.
+func GetZoneAndNameFromInstanceUrl(instanceUrl string) (string, string, error) {
+	// Split the string by "/instances/".
+	components := strings.Split(instanceUrl, "/instances/")
+	if len(components) != 2 {
+		return "", "", fmt.Errorf("error in parsing instance URL: %s, expected it to contain /instances", instanceUrl)
+	}
+	zoneUrl := components[0]
+	name := components[1]
+	zone, err := GetNameFromUrl(zoneUrl)
+	if err != nil {
+		return "", "", fmt.Errorf("error in parsing zone name from its url: %s", err)
+	}
+	return zone, name, nil
+}
+
+// Returns the zone and name of the instance from a GCP instance URL.
+func GetNameFromUrl(url string) (string, error) {
+	// To get name of a resource from its Url, split the string by "/" and use the last element.
+	components := strings.Split(url, "/")
+	if len(components) < 2 {
+		return "", fmt.Errorf("error in parsing URL: %s, expected it to contain /")
+	}
+	return components[len(components)-1], nil
+
+}

--- a/app/kubemci/pkg/gcp/utils/utils_test.go
+++ b/app/kubemci/pkg/gcp/utils/utils_test.go
@@ -1,0 +1,145 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+)
+
+func TestGetZoneAndNameFromIGUrl(t *testing.T) {
+	testCases := []struct {
+		igUrl string
+		name  string
+		zone  string
+		err   bool
+	}{
+		{
+			// Parses as expected.
+			igUrl: "https://www.googleapis.com/compute/v1/projects/fake-project/zones/zone1/instanceGroups/ig1",
+			name:  "ig1",
+			zone:  "zone1",
+			err:   false,
+		},
+		{
+			// Can parse partial urls
+			igUrl: "projects/fake-project/zones/zone1/instanceGroups/ig1",
+			name:  "ig1",
+			zone:  "zone1",
+			err:   false,
+		},
+		{
+			// Generates an error on invalid urls.
+			igUrl: "zone1/ig1",
+			err:   true,
+		},
+	}
+	for i, c := range testCases {
+		zone, name, err := GetZoneAndNameFromIGUrl(c.igUrl)
+		if (err != nil) != c.err {
+			t.Fatalf("test %d: expected err: %v, got: %s", i, c.err, err)
+		}
+		if c.err {
+			continue
+		}
+		if name != c.name {
+			t.Errorf("test %d: expected name: %s, got: %s", i, c.name, name)
+		}
+		if zone != c.zone {
+			t.Errorf("test %d: expected zone: %s, got: %s", i, c.zone, zone)
+		}
+	}
+}
+
+func TestGetZoneAndNameFromInstanceUrl(t *testing.T) {
+	testCases := []struct {
+		url  string
+		name string
+		zone string
+		err  bool
+	}{
+		{
+			// Parses as expected.
+			url:  "https://www.googleapis.com/compute/v1/projects/fake-project/zones/zone1/instances/instance1",
+			name: "instance1",
+			zone: "zone1",
+			err:  false,
+		},
+		{
+			// Can parse partial urls
+			url:  "projects/fake-project/zones/zone1/instances/instance1",
+			name: "instance1",
+			zone: "zone1",
+			err:  false,
+		},
+		{
+			// Generates an error on invalid urls.
+			url: "zone1/ig1",
+			err: true,
+		},
+	}
+	for i, c := range testCases {
+		zone, name, err := GetZoneAndNameFromInstanceUrl(c.url)
+		if (err != nil) != c.err {
+			t.Fatalf("test %d: expected err: %v, got: %s", i, c.err, err)
+		}
+		if c.err {
+			continue
+		}
+		if name != c.name {
+			t.Errorf("test %d: expected name: %s, got: %s", i, c.name, name)
+		}
+		if zone != c.zone {
+			t.Errorf("test %d: expected zone: %s, got: %s", i, c.zone, zone)
+		}
+	}
+}
+
+func TestGetNameFromUrl(t *testing.T) {
+	testCases := []struct {
+		url  string
+		name string
+		err  bool
+	}{
+		{
+			// Parses as expected.
+			url:  "https://www.googleapis.com/compute/v1/projects/fake-project/zones/zone1/zone/zone1",
+			name: "zone1",
+			err:  false,
+		},
+		{
+			// Can parse partial urls
+			url:  "projects/fake-project/zones/zone1/instances/instance1",
+			name: "instance1",
+			err:  false,
+		},
+		{
+			// Generates an error on invalid urls.
+			url: "ig1",
+			err: true,
+		},
+	}
+	for i, c := range testCases {
+		name, err := GetNameFromUrl(c.url)
+		if (err != nil) != c.err {
+			t.Fatalf("test %d: expected err: %v, got: %s", i, c.err, err)
+		}
+		if c.err {
+			continue
+		}
+		if name != c.name {
+			t.Errorf("test %d: expected name: %s, got: %s", i, c.name, name)
+		}
+	}
+}

--- a/examples/zone-printer/app/nginx-dep.yaml
+++ b/examples/zone-printer/app/nginx-dep.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: nginx


### PR DESCRIPTION
Am creating a firewall rule per ingress unlike kube ingress controller which shares a single firewall rule for all ingresses. This is because the target nodes can be different for different multi cluster ingresses in this case, while in single kubernetes cluster case, all ingresses target the same nodes (all nodes in that cluster).


Also, I am fetching the first network tag from one instance in each cluster and using that in the forwarding rule, assuming that all nodes in that cluster has that same network tag. Verified that this is true for single and multi zone GCE and GKE clusters.

cc @csbell @madhusudancs @G-Harmon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/31)
<!-- Reviewable:end -->
