### PR TITLE
Add defaulting to ingress namespace and annotations

### DIFF
--- a/app/kubemci/cmd/create_test.go
+++ b/app/kubemci/cmd/create_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -113,7 +114,11 @@ func TestCreateIngress(t *testing.T) {
 	}
 
 	runFn := func() ([]string, map[string]kubeclient.Interface, error) {
-		return createIngress("kubeconfig", []string{}, "../../../testdata/ingress.yaml")
+		var ing v1beta1.Ingress
+		if err := unmarshallAndApplyDefaults("../../../testdata/ingress.yaml", &ing); err != nil {
+			return nil, nil, err
+		}
+		return createIngress("kubeconfig", []string{}, &ing)
 	}
 	expectedCommands := []ExpectedCommand{
 		{

--- a/app/kubemci/cmd/delete.go
+++ b/app/kubemci/cmd/delete.go
@@ -105,7 +105,7 @@ func runDelete(options *DeleteOptions, args []string) error {
 
 	// Unmarshal the YAML into ingress struct.
 	var ing v1beta1.Ingress
-	if err := unmarshall(options.IngressFilename, &ing); err != nil {
+	if err := unmarshallAndApplyDefaults(options.IngressFilename, &ing); err != nil {
 		return fmt.Errorf("error in unmarshalling the yaml file %s, err: %s", options.IngressFilename, err)
 	}
 	clientset, err := getClientset(options.KubeconfigFilename, "" /*contextName*/)
@@ -118,7 +118,7 @@ func runDelete(options *DeleteOptions, args []string) error {
 	}
 
 	// Delete ingress from all clusters.
-	if delErr := deleteIngress(options.KubeconfigFilename, options.KubeContexts, options.IngressFilename); delErr != nil {
+	if delErr := deleteIngress(options.KubeconfigFilename, options.KubeContexts, &ing); delErr != nil {
 		err = multierror.Append(err, delErr)
 	}
 
@@ -132,23 +132,16 @@ func runDelete(options *DeleteOptions, args []string) error {
 }
 
 // Extracts the contexts from the given kubeconfig and deletes ingress in those context clusters.
-func deleteIngress(kubeconfig string, kubeContexts []string, ingressFilename string) error {
+func deleteIngress(kubeconfig string, kubeContexts []string, ing *v1beta1.Ingress) error {
 	clusters, err := getClusters(kubeconfig, kubeContexts)
 	if err != nil {
 		return err
 	}
-	return deleteIngressInClusters(kubeconfig, ingressFilename, clusters)
+	return deleteIngressInClusters(kubeconfig, ing, clusters)
 }
 
 // Deletes the given ingress in the given list of clusters.
-func deleteIngressInClusters(kubeconfig, ingressFilename string, clusters []string) error {
-	var ing v1beta1.Ingress
-	if err := unmarshall(ingressFilename, &ing); err != nil {
-		return fmt.Errorf("error in unmarshalling the yaml file %s, err: %s", ingressFilename, err)
-	}
-	glog.V(5).Infof("Unmarshaled this ingress:\n%+v", ing)
-
-	// TODO(nikhiljindal): Validate and optionally add the gce-multi-cluster class annotation to the ingress YAML spec.
+func deleteIngressInClusters(kubeconfig string, ing *v1beta1.Ingress, clusters []string) error {
 	var err error
 	for _, c := range clusters {
 		fmt.Println("\nHandling context:", c)

--- a/app/kubemci/cmd/delete_test.go
+++ b/app/kubemci/cmd/delete_test.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"testing"
 
+	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -72,7 +73,11 @@ func TestDeleteIngress(t *testing.T) {
 	})
 
 	runFn := func() ([]string, map[string]kubeclient.Interface, error) {
-		return []string{}, nil, deleteIngress("kubeconfig", []string{}, "../../../testdata/ingress.yaml")
+		var ing v1beta1.Ingress
+		if err := unmarshallAndApplyDefaults("../../../testdata/ingress.yaml", &ing); err != nil {
+			return nil, nil, err
+		}
+		return nil, nil, deleteIngress("kubeconfig", []string{}, &ing)
 	}
 	expectedCommands := []ExpectedCommand{
 		{

--- a/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
+++ b/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
@@ -195,7 +195,7 @@ func (l *LoadBalancerSyncer) getIPAddress(ing *v1beta1.Ingress) (string, error) 
 	if ing.ObjectMeta.Annotations == nil || ing.ObjectMeta.Annotations[key] == "" {
 		// TODO(nikhiljindal): Add logic to reserve a new IP address if user has not specified any.
 		// If we do that then we should also add the new IP address as annotation to the ingress created in clusters.
-		return "", fmt.Errorf("No static ip specified. Multicluster ingresses require a pre-reserved static IP, which can be specified using %s annotation", key)
+		return "", fmt.Errorf("The annotation %v has not been specified. Multicluster ingresses require a pre-reserved static IP", key)
 	}
 	ipName := ing.ObjectMeta.Annotations[key]
 	ip, err := l.ipp.GetGlobalAddress(ipName)


### PR DESCRIPTION
While there, skip the double parsing of the ingress filename so a
single ingress object can be carried through each create/delete
operation.

@nikhiljindal @G-Harmon @madhusudancs @perotinus

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/34)
<!-- Reviewable:end -->
