### PR TITLE
Modify the cobra command setup to print a better help screen, and to enable -v (and other top level flags) to work with subcommands.

### DIFF
--- a/app/kubemci/cmd/cmd.go
+++ b/app/kubemci/cmd/cmd.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"flag"
 	"io"
 
 	"github.com/spf13/cobra"
@@ -33,9 +34,12 @@ func NewCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 		Short: shortDescription,
 		Long:  longDescription,
 	}
-	rootCmd.AddCommand(NewCmdCreate(out, err))
-	rootCmd.AddCommand(NewCmdDelete(out, err))
-	rootCmd.AddCommand(NewCmdGetStatus(out, err))
-	rootCmd.AddCommand(NewCmdGetVersion(out, err))
+	rootCmd.AddCommand(
+		NewCmdCreate(out, err),
+		NewCmdDelete(out, err),
+		NewCmdGetStatus(out, err),
+		NewCmdGetVersion(out, err),
+	)
+	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	return rootCmd
 }

--- a/cmd/kubemci/kubemci.go
+++ b/cmd/kubemci/kubemci.go
@@ -20,17 +20,11 @@ import (
 	"os"
 
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/cmd/kubemci/app"
-	"github.com/golang/glog"
 )
 
 func main() {
 	// Workaround for https://github.com/kubernetes/kubernetes/issues/17162
-	flag.Parse()
-	if glog.V(2) {
-		fmt.Println("Turning on debug logging to STDERR")
-		flag.Set("logtostderr", "true")
-	}
-
+	flag.CommandLine.Parse([]string{})
 	if err := app.Run(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
Fixes #26.

@madhusudancs @csbell @nikhiljindal @G-Harmon 