### PR TITLE
Future-proof Health Check comparison for healthchecksyncer.go.

### DIFF
--- a/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
+++ b/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
@@ -130,6 +130,7 @@ func (l *LoadBalancerSyncer) CreateLoadBalancer(ing *v1beta1.Ingress, forceUpdat
 	// Create backend service. This should always be called after the health check since backend service needs to point to the health check.
 	backendServices, beErr := l.bss.EnsureBackendService(l.lbName, ports, healthChecks, namedPorts, igsForBE, forceUpdate)
 	if beErr != nil {
+		fmt.Printf("Error ensuring backend service for %s: %v", l.lbName, beErr)
 		// Aggregate errors and return all at the end.
 		err = multierror.Append(err, beErr)
 	}

--- a/app/kubemci/pkg/gcp/urlmap/urlmapsyncer.go
+++ b/app/kubemci/pkg/gcp/urlmap/urlmapsyncer.go
@@ -19,9 +19,10 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	compute "google.golang.org/api/compute/v1"
+
 	"github.com/golang/glog"
-	"github.com/hashicorp/go-multierror"
-	"google.golang.org/api/compute/v1"
+	multierror "github.com/hashicorp/go-multierror"
 	"k8s.io/api/extensions/v1beta1"
 	ingresslb "k8s.io/ingress-gce/pkg/loadbalancers"
 	"k8s.io/ingress-gce/pkg/utils"
@@ -219,6 +220,7 @@ func (s *URLMapSyncer) ingToURLMap(ing *v1beta1.Ingress, beMap backendservice.Ba
 	}
 	defaultBackend, beErr := getBackendService(ing.Spec.Backend, ing.Namespace, beMap)
 	if beErr != nil {
+		fmt.Printf("Error getting backend service %s: %v", ing.Spec.Backend.ServiceName, beErr)
 		err = multierror.Append(err, beErr)
 		return nil, err
 	}


### PR DESCRIPTION
Instead of checking for fields we explicitly care about, we switch to a
blacklist of fields that we ignore. This way, future fields are automatically
considered.

Also adds some more logging in error cases.

cc @nikhiljindal @csbell @madhusudancs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/55)
<!-- Reviewable:end -->
