### PR TITLE
Add a "coveralls" target for generating and uploading test coverage.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,5 +37,11 @@ cover:
 	@echo "+ $@"
 	@go list -f '{{if len .TestGoFiles}}"go test -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"{{end}}' $(shell go list ${PKG}/... | grep -v vendor) | xargs -L 1 sh -c
 
+coveralls:
+	@echo "+ $@"
+# Make sure goveralls is installed.
+	@go get github.com/mattn/goveralls
+	@goveralls -repotoken $(cat /etc/coveralls-token/coveralls.txt)
+
 build:
 	go build -a -installsuffix cgo ${GOPATH}/src/${PKG}/cmd/kubemci/kubemci.go


### PR DESCRIPTION
This target installs goveralls (via "go get") and then runs it to generate and upload test coverage data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/63)
<!-- Reviewable:end -->
