### PR TITLE
Fixing the coveralls missing repotoken problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ coveralls:
 	@echo "+ $@"
 # Make sure goveralls is installed.
 	@go get github.com/mattn/goveralls
-	@goveralls -repotoken $(cat /etc/coveralls-token/coveralls.txt)
+	@goveralls -repotoken $(shell cat /etc/coveralls-token/coveralls.txt)
 
 build:
 	go build -a -installsuffix cgo ${GOPATH}/src/${PKG}/cmd/kubemci/kubemci.go


### PR DESCRIPTION
I mainly want to run the tests against this PR, and probably not check it in.

cc @nikhiljindal @BenTheElder

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/66)
<!-- Reviewable:end -->
