### PR TITLE
Get health check path from readiness probe

### DIFF
--- a/app/kubemci/pkg/gcp/healthcheck/fake_healthchecksyncer.go
+++ b/app/kubemci/pkg/gcp/healthcheck/fake_healthchecksyncer.go
@@ -16,6 +16,7 @@ package healthcheck
 
 import (
 	"google.golang.org/api/compute/v1"
+	"k8s.io/client-go/kubernetes"
 	ingressbe "k8s.io/ingress-gce/pkg/backends"
 )
 
@@ -37,7 +38,7 @@ func NewFakeHealthCheckSyncer() HealthCheckSyncerInterface {
 // Ensure this implements HealthCheckSyncerInterface.
 var _ HealthCheckSyncerInterface = &FakeHealthCheckSyncer{}
 
-func (f *FakeHealthCheckSyncer) EnsureHealthCheck(lbName string, ports []ingressbe.ServicePort, force bool) (HealthChecksMap, error) {
+func (f *FakeHealthCheckSyncer) EnsureHealthCheck(lbName string, ports []ingressbe.ServicePort, clients map[string]kubernetes.Interface, force bool) (HealthChecksMap, error) {
 	hcMap := HealthChecksMap{}
 	for _, p := range ports {
 		f.EnsuredHealthChecks = append(f.EnsuredHealthChecks, FakeHealthCheck{

--- a/app/kubemci/pkg/gcp/healthcheck/interfaces.go
+++ b/app/kubemci/pkg/gcp/healthcheck/interfaces.go
@@ -16,6 +16,7 @@ package healthcheck
 
 import (
 	"google.golang.org/api/compute/v1"
+	"k8s.io/client-go/kubernetes"
 	ingressbe "k8s.io/ingress-gce/pkg/backends"
 )
 
@@ -27,7 +28,7 @@ type HealthCheckSyncerInterface interface {
 	// EnsureHealthCheck ensures that the required health checks exist.
 	// Returns a map of port number to the health check for that port. The map contains all the ports for which  it was successfully able to ensure a health check.
 	// In case of no error, the map will contain all the ports from the given array of ports.
-	EnsureHealthCheck(lbName string, ports []ingressbe.ServicePort, forceUpdate bool) (HealthChecksMap, error)
+	EnsureHealthCheck(lbName string, ports []ingressbe.ServicePort, clients map[string]kubernetes.Interface, forceUpdate bool) (HealthChecksMap, error)
 	// DeleteHealthChecks deletes all the health checks that EnsureHealthCheck would have created.
 	DeleteHealthChecks(ports []ingressbe.ServicePort) error
 }

--- a/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
+++ b/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
@@ -113,7 +113,7 @@ func (l *LoadBalancerSyncer) CreateLoadBalancer(ing *v1beta1.Ingress, forceUpdat
 		return err
 	}
 	// Create health checks to be used by the backend service.
-	healthChecks, hcErr := l.hcs.EnsureHealthCheck(l.lbName, ports, forceUpdate)
+	healthChecks, hcErr := l.hcs.EnsureHealthCheck(l.lbName, ports, l.clients, forceUpdate)
 	if hcErr != nil {
 		// Keep aggregating errors and return all at the end, rather than giving up on the first error.
 		err = multierror.Append(err, hcErr)

--- a/app/kubemci/pkg/kubeutils/utils.go
+++ b/app/kubemci/pkg/kubeutils/utils.go
@@ -21,8 +21,13 @@ import (
 
 	"github.com/golang/glog"
 	multierror "github.com/hashicorp/go-multierror"
+	api_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	ingressbe "k8s.io/ingress-gce/pkg/backends"
 )
 
 // GetClients returns a map of cluster name to kubeclient for each cluster context.
@@ -92,4 +97,70 @@ var getClientset = func(kubeconfigPath, contextName string) (kubeclient.Interfac
 	}
 
 	return kubeclient.NewForConfigOrDie(clientConfig), nil
+}
+
+// TODO refactor `getHTTPProbe` in ingress-gce/controller/utils.go so we can share code
+// GetProbe returns a probe that's used for the given nodeport
+func GetProbe(client kubeclient.Interface, port ingressbe.ServicePort) (*api_v1.Probe, error) {
+	svc, err := client.CoreV1().Services(port.SvcName.Namespace).Get(port.SvcName.Name, meta_v1.GetOptions{})
+	if err != nil {
+		fmt.Printf("Unable to find service %v in namespace %v\n", port.SvcName.Name, port.SvcName.Namespace)
+		return nil, err
+	}
+
+	selector := labels.SelectorFromSet(svc.Spec.Selector)
+
+	pl, err := client.CoreV1().Pods(port.SvcName.Namespace).List(meta_v1.ListOptions{
+		LabelSelector: selector.String(),
+	})
+	if err != nil {
+		fmt.Printf("Unable to find pods backing service %v in namespace %v\n", port.SvcName.Name, port.SvcName.Namespace)
+		return nil, err
+	}
+
+	for _, pod := range pl.Items {
+		logStr := fmt.Sprintf("Pod %v matching service selectors %v (targetport %+v)", pod.Name, selector.String(), port.SvcTargetPort)
+
+		for _, c := range pod.Spec.Containers {
+			if !isSimpleHTTPProbe(c.ReadinessProbe) || string(port.Protocol) != string(c.ReadinessProbe.HTTPGet.Scheme) {
+				continue
+			}
+
+			for _, p := range c.Ports {
+				if (port.SvcPort.Type == intstr.Int && port.SvcPort.IntVal == p.ContainerPort) ||
+					(port.SvcPort.Type == intstr.String && port.SvcPort.StrVal == p.Name) {
+
+					readinessProbePort := c.ReadinessProbe.Handler.HTTPGet.Port
+
+					switch readinessProbePort.Type {
+					case intstr.Int:
+						if readinessProbePort.IntVal == p.ContainerPort {
+							return c.ReadinessProbe, nil
+						}
+					case intstr.String:
+						if readinessProbePort.StrVal == p.Name {
+							return c.ReadinessProbe, nil
+						}
+					}
+
+					fmt.Printf("%v: found matching targetPort on container %v, but not on readinessProbe (%+v)\n",
+						logStr, c.Name, c.ReadinessProbe.Handler.HTTPGet.Port)
+				}
+			}
+		}
+
+		fmt.Printf("%v: lacks a matching HTTP probe for use in health checks.\n", logStr)
+	}
+
+	return nil, nil
+}
+
+// TODO copied from ingress-gce/controller/utils.go, refactor so we can share code
+// isSimpleHTTPProbe returns true if the given Probe is:
+// - an HTTPGet probe, as opposed to a tcp or exec probe
+// - has no special host or headers fields, except for possibly an HTTP Host header
+func isSimpleHTTPProbe(probe *api_v1.Probe) bool {
+	return (probe != nil && probe.Handler.HTTPGet != nil && probe.Handler.HTTPGet.Host == "" &&
+		(len(probe.Handler.HTTPGet.HTTPHeaders) == 0 ||
+			(len(probe.Handler.HTTPGet.HTTPHeaders) == 1 && probe.Handler.HTTPGet.HTTPHeaders[0].Name == "Host")))
 }


### PR DESCRIPTION
This PR is not ready but I wanted to open it because I would like some feedback on the approach before continuing. I tried reusing as much as possible from `ingress-gce`, however I chose to copy `GetProbe` and `getHTTPProbe` from `ingress-gce/controller/utils.go`. This is because the `GCETranslator` that was the receiver needed a `LoadBalancerController` to initialize which seemed like unnecessary bloat. One possible solution would be to refactor the code in `ingress-gce` to make it easier to reuse so we could avoid code duplication. I haven't bothered with the tests yet since I'm not sure if this is the way you'd want to implement this.

I tested the implementation manually by running and it works ~with one exception, sometimes it seems like even though the cached informer has been synced it fails to get the correct path and defaults to `/`. I'm not yet sure if there's an issue with some race condition in the syncing or if the error is in this PR.~ EDIT: found the issue, I used the wrong `HasSynced` method when checking if the pod informer had synced