### PR TITLE
Fix flake in create_test.go: sort cluster list.

### DIFF
--- a/app/kubemci/cmd/create_test.go
+++ b/app/kubemci/cmd/create_test.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 
 	"k8s.io/api/extensions/v1beta1"
@@ -109,6 +110,7 @@ func TestCreateIngressInClusters(t *testing.T) {
 		t.Errorf("Expected ingress creation.")
 	}
 	expectedClusters := []string{"cluster1", "cluster2"}
+	sort.Strings(clusters)
 	if !reflect.DeepEqual(clusters, expectedClusters) {
 		t.Errorf("unexpected list of clusters, expected: %v, got: %v", expectedClusters, clusters)
 	}


### PR DESCRIPTION
sometimes this test was failing because the list of clusters returned was in a different ordering than what we were using to compare.

cc @nikhiljindal @csbell

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/75)
<!-- Reviewable:end -->
