### PR TITLE
Add env vars to coverage target that will get Coveralls to post comments back to PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ coveralls:
 	@echo "+ $@"
 # Make sure goveralls is installed.
 	@go get github.com/mattn/goveralls
-	@goveralls -repotoken $(shell cat /etc/coveralls-token/coveralls.txt)
+	@CI_NAME="prow" CI_BUILD_NUMBER=${BUILD_ID} CI_BRANCH=${PULL_BASE_REF} CI_PULL_REQUEST=${PULL_NUMBER} goveralls -repotoken $(shell cat /etc/coveralls-token/coveralls.txt)
 
 build:
 	go build -a -installsuffix cgo ${GOPATH}/src/${PKG}/cmd/kubemci/kubemci.go


### PR DESCRIPTION
…comments back to PR.

I think the best way to test this out is to put up this PR and see if it gets a coverage report.
The firewallrulesyncer.go change is just to make sure coveralls sees some Golang diff. I don't want to submit it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/78)
<!-- Reviewable:end -->
