### PR TITLE
Adding an e2e test to verify the example mci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@
 
 PKG=github.com/GoogleCloudPlatform/k8s-multicluster-ingress
 
+# So that make test is not confused with the test directory.
+.PHONY: test
+
 fmt:
 	@echo "+ $@"
 	@go list -f '{{if len .TestGoFiles}}"gofmt -s -d {{.Dir}}"{{end}}' $(shell go list ${PKG}/... | grep -v vendor) | xargs -L 1 sh -c

--- a/app/kubemci/pkg/kubeutils/utils.go
+++ b/app/kubemci/pkg/kubeutils/utils.go
@@ -28,18 +28,18 @@ import (
 // GetClients returns a map of cluster name to kubeclient for each cluster context.
 // Uses all contexts from the given kubeconfig if kubeContexts is empty.
 func GetClients(kubeconfig string, kubeContexts []string) (map[string]kubeclient.Interface, error) {
-	// Pass the contexts list through getClusterContexts even if we already
+	// Pass the contexts list through GetClusterContexts even if we already
 	// know the contexts to verify that they are valid.
-	contexts, err := getClusterContexts(kubeconfig, kubeContexts)
+	contexts, err := GetClusterContexts(kubeconfig, kubeContexts)
 	if err != nil {
 		return nil, err
 	}
 	return getClientsForContexts(kubeconfig, contexts)
 }
 
-// Extracts and returns the list of contexts from the given kubeconfig.
+// GetClusterContexts extracts and returns the list of contexts from the given kubeconfig.
 // Returns the passed kubeContexts if they are all valid. Returns an error otherwise.
-func getClusterContexts(kubeconfig string, kubeContexts []string) ([]string, error) {
+func GetClusterContexts(kubeconfig string, kubeContexts []string) ([]string, error) {
 	kubectlArgs := []string{"kubectl"}
 	if kubeconfig != "" {
 		kubectlArgs = append(kubectlArgs, fmt.Sprintf("--kubeconfig=%s", kubeconfig))

--- a/app/kubemci/pkg/kubeutils/utils_test.go
+++ b/app/kubemci/pkg/kubeutils/utils_test.go
@@ -46,7 +46,7 @@ func runGetClusterContexts(kubeContexts []string, expectedCmds []expectedCommand
 		i++
 		return output, err
 	}
-	clusters, err := getClusterContexts("kubeconfig", kubeContexts)
+	clusters, err := GetClusterContexts("kubeconfig", kubeContexts)
 	if err != nil {
 		return clusters, err
 	}

--- a/test/e2e/cases/basic.go
+++ b/test/e2e/cases/basic.go
@@ -1,0 +1,105 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/kubeutils"
+)
+
+// Creates a basic multicluster ingress and verifies that it works as expected.
+// TODO(nikhiljindal): Use ginkgo and gomega and possibly reuse k/k e2e framework.
+func RunBasicCreateTest() {
+	// Validate inputs and instantiate required objects first to catch errors early.
+	// TODO(nikhiljindal): User should be able to pass kubeConfigPath.
+	kubeConfigPath := "kubeconfig"
+	// TODO(nikhiljindal): User should be able to pass gcp project.
+	project, err := runCommand([]string{"gcloud", "config", "get-value", "project"})
+	if err == nil && project == "" {
+		glog.Fatalf("unexpected: no default gcp project found. Run gcloud config set project to set a default project.")
+	}
+	// Get clients for all contexts in the kubeconfig.
+	clients, err := kubeutils.GetClients(kubeConfigPath, []string{})
+	if err != nil {
+		glog.Fatalf("unexpected error in instantiating clients for all kubeconfig contexts: %s", err)
+	}
+
+	// Generate random names to be able to run this multiple times.
+	// TODO(nikhiljindal): Use a random namespace name.
+	lbName := randString(10)
+	ipName := randString(10)
+	glog.Infof("Creating an mci %s with ip address name %s", lbName, ipName)
+
+	// Create the zone-printer app in all contexts.
+	// We use kubectl to create the app since it is easier to point it at a
+	// directory with all resources instead of having to create all of them
+	// explicitly with go-client.
+	args := []string{"kubectl", fmt.Sprintf("--kubeconfig=%s", kubeConfigPath), "-f", "examples/zone-printer/app/"}
+	for k := range clients {
+		glog.Infof("Creating app in cluster %s", k)
+		createArgs := append(args, []string{"create", fmt.Sprintf("--context=%s", k)}...)
+		runCommand(createArgs)
+		defer func() {
+			// Delete the app.
+			glog.Infof("Deleting app from cluster %s", k)
+			deleteArgs := append(args, []string{"delete", fmt.Sprintf("--context=%s", k)}...)
+			runCommand(deleteArgs)
+		}()
+	}
+	// Reserve the IP address.
+	runCommand([]string{"gcloud", "compute", "addresses", "create", "--global", ipName})
+	defer func() {
+		runCommand([]string{"gcloud", "compute", "addresses", "delete", "--global", ipName})
+
+	}()
+	// Update the ingress YAML spec to replace $ZP_KUBEMCI_IP with ip name.
+	runCommand([]string{"sed", "-i", "-e", fmt.Sprintf("s/\\$ZP_KUBEMCI_IP/%s/", ipName), "examples/zone-printer/ingress/nginx.yaml"})
+	defer func() {
+		// Put $ZP_KUBEMCI_IP back once done.
+		runCommand([]string{"sed", "-i", "-e", fmt.Sprintf("s/%s/\\$ZP_KUBEMCI_IP/", ipName), "examples/zone-printer/ingress/nginx.yaml"})
+	}()
+
+	// Setup done.
+	// Run kubemci create command.
+	kubemciArgs := []string{"kubemci", "--ingress=examples/zone-printer/ingress/nginx.yaml", fmt.Sprintf("--gcp-project=%s", project), fmt.Sprintf("--kubeconfig=%s", kubeConfigPath)}
+	createArgs := append(kubemciArgs, []string{"create", lbName}...)
+	runCommand(createArgs)
+	defer func() {
+		// Delete the mci.
+		deleteArgs := append(kubemciArgs, []string{"delete", lbName}...)
+		runCommand(deleteArgs)
+	}()
+
+	// Tests
+	// TODO(nikhiljindal): Figure out why is sleep required? get-status should work immediately after create is successful.
+	time.Sleep(5 * time.Second)
+	// Ensure that get-status returns the expected output.
+	getStatusArgs := []string{"kubemci", "get-status", lbName, fmt.Sprintf("--gcp-project=%s", project)}
+	output, _ := runCommand(getStatusArgs)
+	glog.Infof("Output from get-status: %s", output)
+	ipAddress := findIPv4(output)
+	glog.Infof("IP Address: %s", ipAddress)
+	// Ensure that the IP address eventually returns 202.
+	if err := waitForIngress(ipAddress); err != nil {
+		glog.Errorf("error in GET %s: %s", ipAddress, err)
+	}
+
+	// TODO(nikhiljindal): Ensure that the ingress is created and deleted in all
+	// clusters as expected.
+}

--- a/test/e2e/cases/utils.go
+++ b/test/e2e/cases/utils.go
@@ -1,0 +1,134 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	Letters = "abcdefghijklmnopqrstuvwxyz"
+
+	// On average it takes ~6 minutes for a single backend to come online in GCE.
+	LoadBalancerPollTimeout  = 12 * time.Minute
+	LoadBalancerPollInterval = 30 * time.Second
+
+	// IngressReqTimeout is the timeout on a single http request.
+	IngressReqTimeout = 10 * time.Second
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+// Returns a random string of the given length.
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = Letters[rand.Intn(len(Letters))]
+	}
+	return string(b)
+}
+
+func runCommand(args []string) (string, error) {
+	cmd := exec.Command(args[0], args[1:]...)
+	glog.Infof("Running command: %s", strings.Join(args, " "))
+	// TODO(nikhiljindal): Figure out how to use CombinedOutput here to get error message in output.
+	// We dont use it right now because then "gcloud get project" fails.
+	output, err := cmd.Output()
+	if err != nil {
+		err = fmt.Errorf("unexpected error in executing command %s: error: %s, output: %s", strings.Join(args, " "), err, output)
+		glog.Errorf("%s", err)
+	}
+	return strings.TrimSuffix(string(output), "\n"), err
+}
+
+// Returns the first IPv4 address found in the given string.
+func findIPv4(input string) string {
+	numBlock := "(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])"
+	regexPattern := numBlock + "\\." + numBlock + "\\." + numBlock + "\\." + numBlock
+
+	regEx := regexp.MustCompile(regexPattern)
+	return regEx.FindString(input)
+}
+
+// Waits for the ingress paths to be reachable or returns an error if it times out.
+func waitForIngress(ip string) error {
+	timeoutClient := &http.Client{Timeout: IngressReqTimeout}
+	// TODO(nikhiljindal): Add support for https and also verify all paths rather than just the root one.
+	pollURL("http://"+ip, "" /* host */, LoadBalancerPollTimeout, LoadBalancerPollInterval, timeoutClient, false /* expectUnreachable */)
+	return nil
+}
+
+// Polls the given URL until it gets a success response.
+// Copied from /kubernetes/test/e2e/framework/util.go.PollURL.
+// Using it directly imports huge dependencies (all cloud providers, all apimachinery code, etc)
+// TODO(nikhiljindal) Refactor to reuse.
+func pollURL(route, host string, timeout time.Duration, interval time.Duration, httpClient *http.Client, expectUnreachable bool) error {
+	var lastBody string
+	pollErr := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		var err error
+		lastBody, err = simpleGET(httpClient, route, host)
+		if err != nil {
+			glog.Infof("host %s%s: %v unreachable", host, route, err)
+			return expectUnreachable, nil
+		}
+		glog.Infof("Got success response from %s%s: %s", host, route, lastBody)
+		return !expectUnreachable, nil
+	})
+	if pollErr != nil {
+		return fmt.Errorf("Failed to execute a successful GET within %v, Last response body for %v, host %v:\n%v\n\n%v\n",
+			timeout, route, host, lastBody, pollErr)
+	}
+	return nil
+}
+
+// simpleGET executes a get on the given url, returns error if non-200 returned.
+// Copied from /kubernetes/test/e2e/framework/util.go.simpleGET.
+// Using it directly imports huge dependencies (all cloud providers, all apimachinery code, etc)
+// TODO(nikhiljindal) Refactor to reuse.
+func simpleGET(c *http.Client, url, host string) (string, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Host = host
+	res, err := c.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+	rawBody, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+	body := string(rawBody)
+	if res.StatusCode != http.StatusOK {
+		err = fmt.Errorf(
+			"GET returned http error %v", res.StatusCode)
+	}
+	return body, err
+}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1,0 +1,26 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/test/e2e/cases"
+)
+
+func main() {
+	flag.Parse()
+	e2e.RunBasicCreateTest()
+}


### PR DESCRIPTION
Ref https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/48

* Adding the setup to run e2e tests.
* There is a basic create test for now, that creates the example mci and validates that IP address becomes healthy eventually.

Once this is merged, next steps for future PRs:
* Run this e2e test continuously on prow.
* Add more tests.
* Fix TODOs sprinkled all through this code.

cc @csbell @G-Harmon @madhusudancs 