### PR TITLE
Fixing code such that "make fmt vet" pass

### DIFF
--- a/app/kubemci/pkg/gcp/backendservice/backendservicesyncer_test.go
+++ b/app/kubemci/pkg/gcp/backendservice/backendservicesyncer_test.go
@@ -96,7 +96,7 @@ func TestEnsureBackendService(t *testing.T) {
 			},
 		}, []string{igLink}, c.forceUpdate)
 		if (err != nil) != c.ensureErr {
-			t.Errorf("expected an error, got:%v, in ensuring backend service, actual: %v", err)
+			t.Errorf("expected (error != nil) = %v, in ensuring backend service, got error: %v", c.ensureErr, err)
 		}
 		if c.ensureErr {
 			// Can't do validation if we expected an error.
@@ -116,7 +116,7 @@ func TestEnsureBackendService(t *testing.T) {
 			t.Errorf("unexpected health check in backend service. expected: %s, got: %v", c.hcLink, be.HealthChecks)
 		}
 		if be.Port != port || be.PortName != portName {
-			t.Errorf("unexpected port and port name, expected: %s/%s, got: %s/%s", portName, port, be.PortName, be.Port)
+			t.Errorf("unexpected port and port name, expected: %s/%d, got: %s/%d", portName, port, be.PortName, be.Port)
 		}
 		if len(be.Backends) != 1 || be.Backends[0].Group != igLink {
 			t.Errorf("unexpected backends in backend service. expected one backend for %s, got: %v", igLink, be.Backends)

--- a/app/kubemci/pkg/gcp/firewallrule/firewallrulesyncer_test.go
+++ b/app/kubemci/pkg/gcp/firewallrule/firewallrulesyncer_test.go
@@ -49,7 +49,7 @@ func TestEnsureFirewallRule(t *testing.T) {
 			Protocol: "HTTP",
 			SvcName:  types.NamespacedName{Name: kubeSvcName},
 		},
-	}, map[string][]string{"cluster1": []string{igLink}})
+	}, map[string][]string{"cluster1": {igLink}})
 	if err != nil {
 		t.Fatalf("expected no error in ensuring firewall rule, actual: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestDeleteFirewallRule(t *testing.T) {
 			Protocol: "HTTP",
 			SvcName:  types.NamespacedName{Name: kubeSvcName},
 		},
-	}, map[string][]string{"cluster1": []string{igLink}})
+	}, map[string][]string{"cluster1": {igLink}})
 	if err != nil {
 		t.Fatalf("expected no error in ensuring firewall rule, actual: %v", err)
 	}

--- a/app/kubemci/pkg/gcp/forwardingrule/forwardingrulesyncer.go
+++ b/app/kubemci/pkg/gcp/forwardingrule/forwardingrulesyncer.go
@@ -78,7 +78,7 @@ func (s *ForwardingRuleSyncer) EnsureHttpForwardingRule(lbName, ipAddress, targe
 			return nil
 		}
 		if forceUpdate {
-			fmt.Println("Updating existing Forwarding Rule, %v, to match desired state.", name)
+			fmt.Println("Updating existing Forwarding Rule,", name, "to match desired state.")
 			return s.updateForwardingRule(existingFR, desiredFR)
 		} else {
 			fmt.Println("Will not overwrite this differing Forwarding Rule without the --force flag")

--- a/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
+++ b/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
@@ -411,7 +411,7 @@ func getAnyClient(clients map[string]kubeclient.Interface) (kubeclient.Interface
 		return nil, fmt.Errorf("could not find client to send requests to kubernetes cluster")
 	}
 	// Return the client for any cluster.
-	for k, _ := range clients {
+	for k := range clients {
 		return clients[k], nil
 	}
 	return nil, nil

--- a/app/kubemci/pkg/gcp/utils/utils.go
+++ b/app/kubemci/pkg/gcp/utils/utils.go
@@ -56,7 +56,7 @@ func GetNameFromUrl(url string) (string, error) {
 	// To get name of a resource from its Url, split the string by "/" and use the last element.
 	components := strings.Split(url, "/")
 	if len(components) < 2 {
-		return "", fmt.Errorf("error in parsing URL: %s, expected it to contain /")
+		return "", fmt.Errorf("error in parsing URL: %s, expected it to contain /", url)
 	}
 	return components[len(components)-1], nil
 

--- a/app/kubemci/pkg/kubeutils/utils.go
+++ b/app/kubemci/pkg/kubeutils/utils.go
@@ -59,7 +59,7 @@ func getClientsForContexts(kubeconfig string, kubeContexts []string) (map[string
 	for _, c := range kubeContexts {
 		client, clientErr := getClientset(kubeconfig, c)
 		if clientErr != nil {
-			err = multierror.Append(err, fmt.Errorf("Error getting kubectl client interface for context %s:", c, clientErr))
+			err = multierror.Append(err, fmt.Errorf("Error getting kubectl client interface for context %s: %s", c, clientErr))
 			continue
 		}
 		clients[c] = client

--- a/app/kubemci/pkg/kubeutils/utils_test.go
+++ b/app/kubemci/pkg/kubeutils/utils_test.go
@@ -119,7 +119,7 @@ func TestGetClusterContexts(t *testing.T) {
 	for index, c := range testCases {
 		clusters, err := runGetClusterContexts(c.kubeContexts, c.expectedCmds)
 		if c.expectedErr != (err != nil) {
-			t.Errorf("case %d: unexpected error, expected err != nil: %s, got err: %s", index, c.expectedErr, err)
+			t.Errorf("case %d: unexpected error, expected err != nil: %v, got err: %s", index, c.expectedErr, err)
 		}
 		if err != nil {
 			continue
@@ -174,7 +174,7 @@ func TestGetClientsForContexts(t *testing.T) {
 		getClientset = c.getClientset
 		clients, err := getClientsForContexts("kubeconfig", c.kubeContexts)
 		if c.expectedErr != (err != nil) {
-			t.Errorf("case %d: unexpected error, expected err != nil: %s, got err: %s", index, c.expectedErr, err)
+			t.Errorf("case %d: unexpected error, expected err != nil: %v, got err: %s", index, c.expectedErr, err)
 		}
 		if err != nil {
 			continue

--- a/app/kubemci/pkg/kubeutils/utils_test.go
+++ b/app/kubemci/pkg/kubeutils/utils_test.go
@@ -183,7 +183,7 @@ func TestGetClientsForContexts(t *testing.T) {
 		if len(clients) != len(c.expectedClients) {
 			t.Errorf("unexpected set of clients, expected: %v, got: %v", c.expectedClients, clients)
 		}
-		for k, _ := range c.expectedClients {
+		for k := range c.expectedClients {
 			if clients[k] == nil {
 				t.Errorf("unexpected set of clients, expected: %v, got: %v", c.expectedClients, clients)
 			}


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/59 and https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/60

I tried fixing `make lint` as well, but thats a huge change. Will fix it in a separate PR, mostly multiple PRs.

Once this merges will send a PR to run `make fmt vet` as part of our automated tests on each PR so that we do not regress.

cc @csbell @G-Harmon 