### PR TITLE
Adding code to create ssl cert from secret and create https target proxy

### DIFF
--- a/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer_test.go
+++ b/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/firewallrule"
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/forwardingrule"
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/healthcheck"
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/sslcert"
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/targetproxy"
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/urlmap"
 )
@@ -50,6 +51,7 @@ func newLoadBalancerSyncer(lbName string) *LoadBalancerSyncer {
 		tps:    targetproxy.NewFakeTargetProxySyncer(),
 		frs:    forwardingrule.NewFakeForwardingRuleSyncer(),
 		fws:    firewallrule.NewFakeFirewallRuleSyncer(),
+		scs:    sslcert.NewFakeSSLCertSyncer(),
 		clients: map[string]kubeclient.Interface{
 			"cluster1": &fake.Clientset{},
 			"cluster2": &fake.Clientset{},
@@ -58,6 +60,8 @@ func newLoadBalancerSyncer(lbName string) *LoadBalancerSyncer {
 		ipp: ingresslb.NewFakeLoadBalancers("" /*name*/, nil /*namer*/),
 	}
 }
+
+// TODO(nikhiljindal): Add a https ingress test.
 
 func TestCreateLoadBalancer(t *testing.T) {
 	lbName := "lb-name"

--- a/app/kubemci/pkg/gcp/namer/namer.go
+++ b/app/kubemci/pkg/gcp/namer/namer.go
@@ -27,6 +27,7 @@ const (
 	httpForwardingRulePrefix  = "fw"
 	httpsForwardingRulePrefix = "fws"
 	firewallRulePrefix        = "fr"
+	sslCertPrefix             = "ssl"
 
 	// A delimiter used for clarity in naming GCE resources.
 	lbNameDelimiter = "--"
@@ -90,6 +91,10 @@ func (n *Namer) HttpForwardingRuleName() string {
 
 func (n *Namer) FirewallRuleName() string {
 	return n.decorateName(fmt.Sprintf("%v-%v", n.prefix, firewallRulePrefix))
+}
+
+func (n *Namer) SSLCertName() string {
+	return n.decorateName(fmt.Sprintf("%v-%v", n.prefix, sslCertPrefix))
 }
 
 func (n *Namer) decorateName(name string) string {

--- a/app/kubemci/pkg/gcp/sslcert/fake_sslcertsyncer.go
+++ b/app/kubemci/pkg/gcp/sslcert/fake_sslcertsyncer.go
@@ -1,0 +1,56 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sslcert
+
+import (
+	"k8s.io/api/extensions/v1beta1"
+
+	kubeclient "k8s.io/client-go/kubernetes"
+)
+
+const (
+	FakeSSLCertSelfLink = "target/cert/self/link"
+)
+
+type FakeSSLCert struct {
+	LBName  string
+	Ingress *v1beta1.Ingress
+}
+
+type FakeSSLCertSyncer struct {
+	// List of ssl certs that this has been asked to ensure.
+	EnsuredSSLCerts []FakeSSLCert
+}
+
+// Fake ssl cert syncer to be used for tests.
+func NewFakeSSLCertSyncer() SSLCertSyncerInterface {
+	return &FakeSSLCertSyncer{}
+}
+
+// Ensure this implements SSLCertSyncerInterface.
+var _ SSLCertSyncerInterface = &FakeSSLCertSyncer{}
+
+func (f *FakeSSLCertSyncer) EnsureSSLCert(lbName string, ing *v1beta1.Ingress, client kubeclient.Interface, forceUpdate bool) (string, error) {
+	f.EnsuredSSLCerts = append(f.EnsuredSSLCerts, FakeSSLCert{
+		LBName:  lbName,
+		Ingress: ing,
+	})
+	return FakeSSLCertSelfLink, nil
+}
+
+func (f *FakeSSLCertSyncer) DeleteSSLCert() error {
+	f.EnsuredSSLCerts = nil
+	return nil
+}

--- a/app/kubemci/pkg/gcp/sslcert/interfaces.go
+++ b/app/kubemci/pkg/gcp/sslcert/interfaces.go
@@ -1,0 +1,31 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sslcert
+
+import (
+	"k8s.io/api/extensions/v1beta1"
+
+	kubeclient "k8s.io/client-go/kubernetes"
+)
+
+// SSLCertSyncerInterface is an interface to manage GCP ssl certs.
+type SSLCertSyncerInterface interface {
+	// EnsureSSLCert ensures that the required ssl cert exists for the given ingress.
+	// Will only change an existing SSL cert if forceUpdate=True.
+	// Returns the self link for the ensured ssl cert.
+	EnsureSSLCert(lbName string, ing *v1beta1.Ingress, client kubeclient.Interface, forceUpdate bool) (string, error)
+	// DeleteSSLCert deletes the ssl cert that EnsureSSLCert would have created.
+	DeleteSSLCert() error
+}

--- a/app/kubemci/pkg/gcp/sslcert/sslcertsyncer.go
+++ b/app/kubemci/pkg/gcp/sslcert/sslcertsyncer.go
@@ -1,0 +1,181 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sslcert
+
+import (
+	"fmt"
+	"reflect"
+
+	compute "google.golang.org/api/compute/v1"
+
+	"github.com/golang/glog"
+	"k8s.io/api/extensions/v1beta1"
+	kubeclient "k8s.io/client-go/kubernetes"
+	"k8s.io/ingress-gce/pkg/annotations"
+	ingresslb "k8s.io/ingress-gce/pkg/loadbalancers"
+	"k8s.io/ingress-gce/pkg/tls"
+
+	utilsnamer "github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/namer"
+)
+
+// SSLCertSyncer manages GCP ssl certs for multicluster GCP L7 load balancers.
+type SSLCertSyncer struct {
+	namer *utilsnamer.Namer
+	// Instance of SSLCertProvider interface for calling GCE SSLCert APIs.
+	// There is no separate SSLCertProvider interface, so we use the bigger LoadBalancers interface here.
+	scp ingresslb.LoadBalancers
+}
+
+func NewSSLCertSyncer(namer *utilsnamer.Namer, scp ingresslb.LoadBalancers) SSLCertSyncerInterface {
+	return &SSLCertSyncer{
+		namer: namer,
+		scp:   scp,
+	}
+}
+
+// Ensure this implements SSLCertSyncerInterface.
+var _ SSLCertSyncerInterface = &SSLCertSyncer{}
+
+// See interfaces.go comment.
+func (s *SSLCertSyncer) EnsureSSLCert(lbName string, ing *v1beta1.Ingress, client kubeclient.Interface, forceUpdate bool) (string, error) {
+	fmt.Println("Ensuring ssl cert")
+	annotations := annotations.IngAnnotations(ing.ObjectMeta.Annotations)
+	if annotations.UseNamedTLS() != "" {
+		return s.ensurePreSharedSSLCert(lbName, ing, forceUpdate)
+	}
+	return s.ensureSecretSSLCert(lbName, ing, client, forceUpdate)
+}
+
+func (s *SSLCertSyncer) ensurePreSharedSSLCert(lbName string, ing *v1beta1.Ingress, forceUpdate bool) (string, error) {
+	err := fmt.Errorf("Pre shared cert is not supported by this tool yet")
+	fmt.Println(err)
+	return "", err
+}
+
+func (s *SSLCertSyncer) ensureSecretSSLCert(lbName string, ing *v1beta1.Ingress, client kubeclient.Interface, forceUpdate bool) (string, error) {
+	var err error
+	desiredCert, err := s.desiredSSLCert(lbName, ing, client)
+	if err != nil {
+		err = fmt.Errorf("error %s in computing desired ssl cert", err)
+		fmt.Println(err)
+		return "", err
+	}
+	name := desiredCert.Name
+	// Check if ssl cert already exists.
+	existingCert, err := s.scp.GetSslCertificate(name)
+	if err == nil {
+		fmt.Println("ssl cert", name, "exists already. Checking if it matches our desired ssl cert", name)
+		// SSL cert with that name exists already. Check if it matches what we want.
+		if sslCertMatches(*desiredCert, *existingCert) {
+			// Nothing to do. Desired ssl cert exists already.
+			fmt.Println("Desired ssl cert exists already")
+			return existingCert.SelfLink, nil
+		}
+		fmt.Println("Existing SSL certificate does not match the desired certificate. Note that updating existing certificate will cause downtime.")
+		if forceUpdate {
+			fmt.Println("Updating existing SSL cert", name, "to match the desired state")
+			return s.updateSSLCert(desiredCert)
+		} else {
+			fmt.Println("Will not overwrite this differing SSL cert without the --force flag.")
+			return "", fmt.Errorf("will not overwrite SSL cert without --force")
+		}
+	}
+	glog.V(5).Infof("Got error %s while trying to get existing ssl cert %s. Will try to create new one", err, name)
+	// TODO: Handle non NotFound errors. We should create only if the error is NotFound.
+	// Create the ssl cert.
+	return s.createSSLCert(desiredCert)
+}
+
+func (s *SSLCertSyncer) DeleteSSLCert() error {
+	name := s.namer.SSLCertName()
+	fmt.Println("Deleting ssl cert", name)
+	err := s.scp.DeleteSslCertificate(name)
+	if err != nil {
+		fmt.Println("error", err, "in deleting ssl cert", name)
+		return err
+	}
+	fmt.Println("ssl cert", name, "deleted successfully")
+	return nil
+}
+
+func (s *SSLCertSyncer) updateSSLCert(desiredCert *compute.SslCertificate) (string, error) {
+	name := desiredCert.Name
+	fmt.Println("Deleting existing ssl cert", name, "and recreating it to match the desired state.")
+	// SSL Cert does not support update. We need to delete and then create again.
+	err := s.scp.DeleteSslCertificate(name)
+	if err != nil {
+		return "", fmt.Errorf("error in deleting ssl cert %s: %s", name, err)
+	}
+	_, err = s.scp.CreateSslCertificate(desiredCert)
+	if err != nil {
+		return "", fmt.Errorf("error in creating ssl cert %s: %s", name, err)
+	}
+	fmt.Println("SSL cert", name, "updated successfully")
+	sc, err := s.scp.GetSslCertificate(name)
+	if err != nil {
+		return "", err
+	}
+	return sc.SelfLink, nil
+}
+
+func (s *SSLCertSyncer) createSSLCert(desiredCert *compute.SslCertificate) (string, error) {
+	name := desiredCert.Name
+	fmt.Println("Creating ssl cert", name)
+	glog.V(5).Infof("Creating ssl cert %v", desiredCert)
+	_, err := s.scp.CreateSslCertificate(desiredCert)
+	if err != nil {
+		return "", err
+	}
+	fmt.Println("SSL cert", name, "created successfully")
+	sc, err := s.scp.GetSslCertificate(name)
+	if err != nil {
+		return "", err
+	}
+	return sc.SelfLink, nil
+}
+
+func sslCertMatches(desiredCert, existingCert compute.SslCertificate) bool {
+	// Clear output-only fields to do our comparison
+	existingCert.CreationTimestamp = ""
+	existingCert.Kind = ""
+	existingCert.Id = 0
+	existingCert.SelfLink = ""
+
+	// NOTE: We do not print the diff, to not leak the certificate.
+	return reflect.DeepEqual(existingCert, desiredCert)
+}
+
+func (s *SSLCertSyncer) desiredSSLCert(lbName string, ing *v1beta1.Ingress, client kubeclient.Interface) (*compute.SslCertificate, error) {
+	// Check for secret.
+	tlsLoader := &tls.TLSCertsFromSecretsLoader{Client: client}
+	cert, err := tlsLoader.Load(ing)
+	if err != nil {
+		err = fmt.Errorf("Error in fetching certs for ing %s/%s: %s", ing.Namespace, ing.Name, err)
+		fmt.Println(err)
+		return nil, err
+	}
+	if cert == nil {
+		err = fmt.Errorf("could not fetch certs for ing %s/%s", ing.Namespace, ing.Name)
+		fmt.Println(err)
+		return nil, err
+	}
+	// Compute the desired ssl cert.
+	return &compute.SslCertificate{
+		Name:        s.namer.SSLCertName(),
+		Description: fmt.Sprintf("SSL cert for kubernetes multicluster loadbalancer %s", lbName),
+		Certificate: cert.Cert,
+		PrivateKey:  cert.Key,
+	}, nil
+}

--- a/app/kubemci/pkg/gcp/sslcert/sslcertsyncer_test.go
+++ b/app/kubemci/pkg/gcp/sslcert/sslcertsyncer_test.go
@@ -1,0 +1,156 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sslcert
+
+import (
+	"strings"
+	"testing"
+
+	api_v1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	kubeclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	core "k8s.io/client-go/testing"
+	ingresslb "k8s.io/ingress-gce/pkg/loadbalancers"
+
+	utilsnamer "github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/namer"
+	"github.com/golang/glog"
+)
+
+func TestEnsureSSLCert(t *testing.T) {
+	lbName := "lb-name"
+	// Should create the ssl cert as expected.
+	scp := ingresslb.NewFakeLoadBalancers("" /* name */, nil /* namer */)
+	namer := utilsnamer.NewNamer("mci1", lbName)
+	certName := namer.SSLCertName()
+	scs := NewSSLCertSyncer(namer, scp)
+	// GET should return NotFound.
+	if _, err := scp.GetSslCertificate(certName); err == nil {
+		t.Fatalf("expected NotFound error, got nil")
+	}
+	testCases := []struct {
+		desc string
+		// In's
+		lBName      string
+		forceUpdate bool
+		// Out's
+		ensureErr bool
+	}{
+		{
+			desc:        "initial write (force=false)",
+			lBName:      "lb-name",
+			forceUpdate: false,
+			ensureErr:   false,
+		},
+		{
+			desc:        "write same (force=false)",
+			lBName:      "lb-name",
+			forceUpdate: false,
+			ensureErr:   false,
+		},
+		{
+			desc:        "write different (force=false)",
+			lBName:      "lb-name2",
+			forceUpdate: false,
+			ensureErr:   true,
+		},
+		{
+			desc:        "write different (force=true)",
+			lBName:      "lb-name3",
+			forceUpdate: true,
+			ensureErr:   false,
+		},
+	}
+
+	ing, client := setupIng()
+	if _, err := scs.EnsureSSLCert(lbName, ing, client, false /*forceUpdate*/); err != nil {
+		for _, c := range testCases {
+			glog.Infof("\nTest case: %s", c.desc)
+			_, err := scs.EnsureSSLCert(c.lBName, ing, client, c.forceUpdate)
+			if (err != nil) != c.ensureErr {
+				t.Errorf("Ensuring SSL cert... expected err? %v. actual: %v", c.ensureErr, err)
+			}
+			if c.ensureErr {
+				t.Logf("Skipping validation.")
+				continue
+			}
+			// Verify that GET does not return NotFound.
+			cert, err := scp.GetSslCertificate(certName)
+			if err != nil {
+				t.Errorf("expected nil error, actual: %v", err)
+			}
+			if !strings.Contains(cert.Description, c.lBName) {
+				t.Errorf("Expected description to contain lb name (%s). got:%s", c.lBName, cert.Description)
+			}
+		}
+	}
+}
+
+func setupIng() (*v1beta1.Ingress, kubeclient.Interface) {
+	// Create ingress with secret for SSL cert.
+	svcName := "svcName"
+	svcPort := "svcPort"
+	secretName := "certSecret"
+	ing := &v1beta1.Ingress{
+		Spec: v1beta1.IngressSpec{
+			TLS: []v1beta1.IngressTLS{
+				{
+					SecretName: secretName,
+				},
+			},
+			Backend: &v1beta1.IngressBackend{
+				ServiceName: svcName,
+				ServicePort: intstr.FromString(svcPort),
+			},
+		},
+	}
+	client := &fake.Clientset{}
+	// Add a reaction to return secret with a fake ssl cert.
+	client.AddReactor("get", "secrets", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		ret = &api_v1.Secret{
+			Data: map[string][]byte{
+				api_v1.TLSCertKey:       []byte("cert"),
+				api_v1.TLSPrivateKeyKey: []byte("key"),
+			},
+		}
+		return true, ret, nil
+	})
+	return ing, client
+}
+
+func TestDeleteSSLCert(t *testing.T) {
+	lbName := "lb-name"
+	// Should create the ssl cert as expected.
+	scp := ingresslb.NewFakeLoadBalancers("" /* name */, nil /* namer */)
+	namer := utilsnamer.NewNamer("mci1", lbName)
+	certName := namer.SSLCertName()
+	scs := NewSSLCertSyncer(namer, scp)
+	ing, client := setupIng()
+	if _, err := scs.EnsureSSLCert(lbName, ing, client, false /*forceUpdate*/); err != nil {
+		t.Fatalf("expected no error in ensuring ssl cert, actual: %v", err)
+	}
+	if _, err := scp.GetSslCertificate(certName); err != nil {
+		t.Fatalf("expected nil error, actual: %v", err)
+	}
+	// Verify that GET fails after DELETE
+	if err := scs.DeleteSSLCert(); err != nil {
+		t.Fatalf("unexpected err while deleting SSL cert: %s", err)
+	}
+	if _, err := scp.GetSslCertificate(certName); err == nil {
+		t.Errorf("unexpected nil error, expected NotFound")
+	}
+}

--- a/app/kubemci/pkg/gcp/targetproxy/fake_targetproxysyncer.go
+++ b/app/kubemci/pkg/gcp/targetproxy/fake_targetproxysyncer.go
@@ -21,6 +21,8 @@ const (
 type FakeTargetProxy struct {
 	LBName string
 	UmLink string
+	// Link to the SSL certificate. This is present only for HTTPS target proxies.
+	CertLink string
 }
 
 type FakeTargetProxySyncer struct {
@@ -40,6 +42,15 @@ func (f *FakeTargetProxySyncer) EnsureHttpTargetProxy(lbName, umLink string, for
 	f.EnsuredTargetProxies = append(f.EnsuredTargetProxies, FakeTargetProxy{
 		LBName: lbName,
 		UmLink: umLink,
+	})
+	return FakeTargetProxySelfLink, nil
+}
+
+func (f *FakeTargetProxySyncer) EnsureHttpsTargetProxy(lbName, umLink, certLink string, forceUpdate bool) (string, error) {
+	f.EnsuredTargetProxies = append(f.EnsuredTargetProxies, FakeTargetProxy{
+		LBName:   lbName,
+		UmLink:   umLink,
+		CertLink: certLink,
 	})
 	return FakeTargetProxySelfLink, nil
 }

--- a/app/kubemci/pkg/gcp/targetproxy/interfaces.go
+++ b/app/kubemci/pkg/gcp/targetproxy/interfaces.go
@@ -22,6 +22,13 @@ type TargetProxySyncerInterface interface {
 	// is true.
 	// Returns the self link for the ensured proxy.
 	EnsureHttpTargetProxy(lbName, urlMapLink string, forceUpdate bool) (string, error)
-	// DeleteTargetProxies deletes the target proxies that EnsureTargetProxy would have created.
+	// EnsureHttpsTargetProxy ensures that the required https target proxy
+	// exists for the given load balancer and url map link. Will only
+	// overwrite an existing and different http target proxy if forceUpdate
+	// is true.
+	// Returns the self link for the ensured proxy.
+	EnsureHttpsTargetProxy(lbName, urlMapLink, certLink string, forceUpdate bool) (string, error)
+	// DeleteTargetProxies deletes the target proxies that EnsureHttpTargetProxy
+	// and EnsureHttpsTargetProxy would have created.
 	DeleteTargetProxies() error
 }

--- a/app/kubemci/pkg/gcp/targetproxy/targetproxysyncer_test.go
+++ b/app/kubemci/pkg/gcp/targetproxy/targetproxysyncer_test.go
@@ -90,28 +90,115 @@ func TestEnsureTargetHttpProxy(t *testing.T) {
 			t.Errorf("unexpected target proxy self link. expected: %s, got: %s", tpLink, tp.SelfLink)
 		}
 	}
-	// TODO(nikhiljindal): Test update existing target proxy.
+}
+
+func TestEnsureTargetHttpsProxy(t *testing.T) {
+	lbName := "lb-name"
+	// Should create the target proxy as expected.
+	tpp := ingresslb.NewFakeLoadBalancers("" /*name*/, nil /*namer*/)
+	namer := utilsnamer.NewNamer("mci1", lbName)
+	tpName := namer.TargetHttpsProxyName()
+	tps := NewTargetProxySyncer(namer, tpp)
+	// GET should return NotFound.
+	if _, err := tpp.GetTargetHttpProxy(tpName); err == nil {
+		t.Fatalf("expected NotFound error, got nil")
+	}
+	testCases := []struct {
+		desc string
+		// In's
+		umLink      string
+		certLink    string
+		forceUpdate bool
+		// Out's
+		ensureErr bool
+	}{
+		{
+			desc:        "initial write (force=false)",
+			umLink:      "http://google/compute/v1/projects/p/global/urlMaps/map",
+			certLink:    "http://google/compute/v1/projects/p/global/sslCerts/cert",
+			forceUpdate: false,
+			ensureErr:   false,
+		},
+		{
+			desc:        "write same (force=false)",
+			umLink:      "http://google/compute/v1/projects/p/global/urlMaps/map",
+			certLink:    "http://google/compute/v1/projects/p/global/sslCerts/cert",
+			forceUpdate: false,
+			ensureErr:   false,
+		},
+		{
+			desc:        "write different (force=false)",
+			umLink:      "http://google/compute/v1/projects/p/global/urlMaps/map2",
+			certLink:    "http://google/compute/v1/projects/p/global/sslCerts/cert",
+			forceUpdate: false,
+			ensureErr:   true,
+		},
+		{
+			desc:        "write different (force=true)",
+			umLink:      "http://google/compute/v1/projects/p/global/urlMaps/map3",
+			certLink:    "http://google/compute/v1/projects/p/global/sslCerts/cert",
+			forceUpdate: true,
+			ensureErr:   false,
+		},
+	}
+	for _, c := range testCases {
+		glog.Infof("test case:%v", c.desc)
+		tpLink, err := tps.EnsureHttpsTargetProxy(lbName, c.umLink, c.certLink, c.forceUpdate)
+		if (err != nil) != c.ensureErr {
+			glog.Errorf("expected_error:%v Got Error:%v", c.ensureErr, err)
+			t.Errorf("in ensuring target proxy, expected error? %v, actual: %v", c.ensureErr, err)
+		}
+		// Verify that GET does not return NotFound.
+		tp, err := tpp.GetTargetHttpsProxy(tpName)
+		if err != nil {
+			t.Errorf("expected nil error, actual: %v", err)
+		}
+		if c.ensureErr {
+			// Skip validation in error scenarios.
+			continue
+		}
+		if tp.UrlMap != c.umLink {
+			t.Errorf("unexpected UrlMap link in target proxy. expected: %s, actual: %s", c.umLink, tp.UrlMap)
+		}
+		if len(tp.SslCertificates) != 1 || tp.SslCertificates[0] != c.certLink {
+			t.Errorf("unexpected certificates link in target proxy. expected: %s, actual: %s", c.certLink, tp.SslCertificates)
+		}
+		if tp.SelfLink != tpLink {
+			t.Errorf("unexpected target proxy self link. expected: %s, got: %s", tpLink, tp.SelfLink)
+		}
+	}
 }
 
 func TestDeleteTargetProxies(t *testing.T) {
 	lbName := "lb-name"
 	umLink := "selfLink"
-	// Should create the target proxy as expected.
+	certLink := "certSelfLink"
+	// Create both http and https and verify that it deletes both.
 	tpp := ingresslb.NewFakeLoadBalancers("" /*name*/, nil /*namer*/)
 	namer := utilsnamer.NewNamer("mci1", lbName)
-	tpName := namer.TargetHttpProxyName()
+	httpTpName := namer.TargetHttpProxyName()
+	httpsTpName := namer.TargetHttpsProxyName()
 	tps := NewTargetProxySyncer(namer, tpp)
 	if _, err := tps.EnsureHttpTargetProxy(lbName, umLink, false /*forceUpdate*/); err != nil {
-		t.Fatalf("expected no error in ensuring target proxy, actual: %v", err)
+		t.Fatalf("expected no error in ensuring http target proxy, actual: %v", err)
 	}
-	if _, err := tpp.GetTargetHttpProxy(tpName); err != nil {
+	if _, err := tpp.GetTargetHttpProxy(httpTpName); err != nil {
+		t.Fatalf("expected nil error, actual: %v", err)
+	}
+	if _, err := tps.EnsureHttpsTargetProxy(lbName, umLink, certLink, false /*forceUpdate*/); err != nil {
+		t.Fatalf("expected no error in ensuring https target proxy, actual: %v", err)
+	}
+	if _, err := tpp.GetTargetHttpsProxy(httpsTpName); err != nil {
 		t.Fatalf("expected nil error, actual: %v", err)
 	}
 	// Verify that GET fails after DELETE.
 	if err := tps.DeleteTargetProxies(); err != nil {
 		t.Fatalf("unexpected error while deleting target proxies: %s", err)
 	}
-	if _, err := tpp.GetTargetHttpProxy(tpName); err == nil {
+	if _, err := tpp.GetTargetHttpProxy(httpTpName); err == nil {
+		t.Fatalf("unexpected nil error, expected NotFound")
+	}
+	if _, err := tpp.GetTargetHttpsProxy(httpTpName); err == nil {
 		t.Fatalf("unexpected nil error, expected NotFound")
 	}
 }


### PR DESCRIPTION
Ref https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/46

This is a step towards adding HTTPS support to kubemci.

It has the following main changes:
* Adding a SSLCertSyncer that manages certs for a given ingress
* Updating TargetProxySyncer to manage https target proxies as well.

In ingress-gce, Users can specify certs in 2 ways:
* Using ingress.Spec.TLS.SecretName
* Using ` ingress.gcp.kubernetes.io/pre-shared-cert` annotation.

SSLCertSyncer supports only the first for now. Will add support for the annotation in next PR.
Also note, that updating the secret will cause downtime for now, since it deletes and then recreates the ssl certificate.

cc @csbell @G-Harmon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/92)
<!-- Reviewable:end -->
