### PR TITLE
Adding code to create an https forwarding rule

### DIFF
--- a/app/kubemci/pkg/gcp/forwardingrule/fake_forwardingrulesyncer.go
+++ b/app/kubemci/pkg/gcp/forwardingrule/fake_forwardingrulesyncer.go
@@ -25,6 +25,7 @@ type FakeForwardingRule struct {
 	IPAddress string
 	TPLink    string
 	Clusters  []string
+	IsHTTPS   bool
 }
 
 type FakeForwardingRuleSyncer struct {
@@ -46,6 +47,17 @@ func (f *FakeForwardingRuleSyncer) EnsureHttpForwardingRule(lbName, ipAddress, t
 		IPAddress: ipAddress,
 		TPLink:    targetProxyLink,
 		Clusters:  clusters,
+	})
+	return nil
+}
+
+func (f *FakeForwardingRuleSyncer) EnsureHttpsForwardingRule(lbName, ipAddress, targetProxyLink string, clusters []string, forceUpdate bool) error {
+	f.EnsuredForwardingRules = append(f.EnsuredForwardingRules, FakeForwardingRule{
+		LBName:    lbName,
+		IPAddress: ipAddress,
+		TPLink:    targetProxyLink,
+		Clusters:  clusters,
+		IsHTTPS:   true,
 	})
 	return nil
 }

--- a/app/kubemci/pkg/gcp/forwardingrule/interfaces.go
+++ b/app/kubemci/pkg/gcp/forwardingrule/interfaces.go
@@ -24,7 +24,12 @@ type ForwardingRuleSyncerInterface interface {
 	// clusters is the list of clusters across which the load balancer is spread.
 	// Will only change an existing rule if forceUpdate = True.
 	EnsureHttpForwardingRule(lbName, ipAddress, targetProxyLink string, clusters []string, forceUpdate bool) error
-	// DeleteForwardingRules deletes the forwarding rules that EnsureForwardingRule would have created.
+	// EnsureHttpsForwardingRule ensures that the required https forwarding rule exists.
+	// clusters is the list of clusters across which the load balancer is spread.
+	// Will only change an existing rule if forceUpdate = True.
+	EnsureHttpsForwardingRule(lbName, ipAddress, targetProxyLink string, clusters []string, forceUpdate bool) error
+	// DeleteForwardingRules deletes the forwarding rules that
+	// EnsureHttpForwardingRule and EnsureHttpsForwardingRule would have created.
 	DeleteForwardingRules() error
 	// GetLoadBalancerStatus returns the struct describing the status of the given load balancer.
 	GetLoadBalancerStatus(lbName string) (*status.LoadBalancerStatus, error)

--- a/test/e2e/cases/basic.go
+++ b/test/e2e/cases/basic.go
@@ -28,7 +28,7 @@ import (
 func RunBasicCreateTest() {
 	// Validate inputs and instantiate required objects first to catch errors early.
 	// TODO(nikhiljindal): User should be able to pass kubeConfigPath.
-	kubeConfigPath := "kubeconfig"
+	kubeConfigPath := "minKubeconfig"
 	// TODO(nikhiljindal): User should be able to pass gcp project.
 	project, err := runCommand([]string{"gcloud", "config", "get-value", "project"})
 	if err == nil && project == "" {


### PR DESCRIPTION
Ref #46

Adding code to create an https forwarding rule. This completes the code to create an https ingress using secret certs.
We still need to add support for pre-shared certs. Also need to add a test for https ingress.


Ignore the first commit which is part of https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/pull/92 (will rebase once it merges).

cc @csbell @G-Harmon 