### PR TITLE
Adding an e2e test to verify an HTTPS ingress

### DIFF
--- a/examples/zone-printer/ingress/https-ingress.yaml
+++ b/examples/zone-printer/ingress/https-ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: nginx
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: $ZP_KUBEMCI_IP
+    kubernetes.io/ingress.class: gce-multi-cluster
+spec:
+  tls:
+  # This assumes tls-secret exists.
+  - secretName: tls-secret
+  backend:
+    serviceName: nginx
+    servicePort: 80

--- a/test/e2e/cases/basic.go
+++ b/test/e2e/cases/basic.go
@@ -20,36 +20,47 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	kubeclient "k8s.io/client-go/kubernetes"
 
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/kubeutils"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
-var kubemci_bin = "./kubemci"
+// kubemci is expected to be in PATH.
+var kubemci = "kubemci"
 
 // Creates a basic multicluster ingress and verifies that it works as expected.
 // TODO(nikhiljindal): Use ginkgo and gomega and possibly reuse k/k e2e framework.
 func RunBasicCreateTest() {
+	project, kubeConfigPath, lbName, ipName, clients := setup()
+	defer func() {
+		cleanup(kubeConfigPath, lbName, ipName, clients)
+	}()
+	testHTTPIngress(project, kubeConfigPath, lbName)
+	testHTTPSIngress(project, kubeConfigPath, lbName, clients)
+}
+
+func setup() (project, kubeConfigPath, lbName, ipName string, clients map[string]kubeclient.Interface) {
 	// Validate inputs and instantiate required objects first to catch errors early.
 	// TODO(nikhiljindal): User should be able to pass kubeConfigPath.
-	kubeConfigPath := "minKubeconfig"
+	kubeConfigPath = "minKubeconfig"
 	// TODO(nikhiljindal): User should be able to pass gcp project.
 	project, err := runCommand([]string{"gcloud", "config", "get-value", "project"})
 	if err != nil {
-		glog.Fatalf("Error getting default project:%v", err)
+		glog.Fatalf("Error getting default project: %v", err)
 	} else if project == "" {
 		glog.Fatalf("unexpected: no default gcp project found. Run gcloud config set project to set a default project.")
 	}
 	// Get clients for all contexts in the kubeconfig.
-	clients, err := kubeutils.GetClients(kubeConfigPath, []string{})
+	clients, err = kubeutils.GetClients(kubeConfigPath, []string{})
 	if err != nil {
 		glog.Fatalf("unexpected error in instantiating clients for all kubeconfig contexts: %s", err)
 	}
 
 	// Generate random names to be able to run this multiple times.
 	// TODO(nikhiljindal): Use a random namespace name.
-	lbName := randString(10)
-	ipName := randString(10)
+	lbName = randString(10)
+	ipName = randString(10)
 	glog.Infof("Creating an mci named '%s' with ip address named '%s'", lbName, ipName)
 
 	// Create the zone-printer app in all contexts.
@@ -62,60 +73,135 @@ func RunBasicCreateTest() {
 		createArgs := append(args, []string{"create", fmt.Sprintf("--context=%s", k)}...)
 		// kubectl create may fail if this was setup in a previous run.
 		runCommand(createArgs)
-		defer func() {
-			// Delete the app.
-			glog.Infof("Deleting app from cluster %s", k)
-			deleteArgs := append(args, []string{"delete", fmt.Sprintf("--context=%s", k)}...)
-			runCommand(deleteArgs)
-		}()
 	}
 	// Reserve the IP address.
 	if _, err := runCommand([]string{"gcloud", "compute", "addresses", "create", "--global", ipName}); err != nil {
 		glog.Fatalf("Error creating IP address:%v", err)
 	}
-	defer func() {
-		runCommand([]string{"gcloud", "compute", "addresses", "delete", "--global", ipName})
-
-	}()
-	// Update the ingress YAML spec to replace $ZP_KUBEMCI_IP with ip name.
+	// Update the ingress YAML specs to replace $ZP_KUBEMCI_IP with ip name.
 	if _, err := runCommand([]string{"sed", "-i", "-e", fmt.Sprintf("s/\\$ZP_KUBEMCI_IP/%s/", ipName), "examples/zone-printer/ingress/nginx.yaml"}); err != nil {
-		glog.Fatalf("Error updating yaml with sed:%v", err)
+		glog.Fatalf("Error updating http ingress yaml with sed: %v", err)
 	}
-	defer func() {
-		// Put $ZP_KUBEMCI_IP back once done.
-		runCommand([]string{"sed", "-i", "-e", fmt.Sprintf("s/%s/\\$ZP_KUBEMCI_IP/", ipName), "examples/zone-printer/ingress/nginx.yaml"})
-	}()
+	if _, err := runCommand([]string{"sed", "-i", "-e", fmt.Sprintf("s/\\$ZP_KUBEMCI_IP/%s/", ipName), "examples/zone-printer/ingress/https-ingress.yaml"}); err != nil {
+		glog.Fatalf("Error updating https ingress yaml with sed: %v", err)
+	}
 
-	// Setup done.
+	return project, kubeConfigPath, lbName, ipName, clients
+}
+
+func cleanup(kubeConfigPath, lbName, ipName string, clients map[string]kubeclient.Interface) {
+	// Delete the zone-printer app from all contexts.
+	args := []string{"kubectl", fmt.Sprintf("--kubeconfig=%s", kubeConfigPath), "-f", "examples/zone-printer/app/"}
+	for k := range clients {
+		glog.Infof("Deleting app from cluster %s", k)
+		deleteArgs := append(args, []string{"delete", fmt.Sprintf("--context=%s", k)}...)
+		runCommand(deleteArgs)
+	}
+	// Release the IP address.
+	runCommand([]string{"gcloud", "compute", "addresses", "delete", "--global", ipName})
+
+	// Update the ingress YAML spec to put $ZP_KUBEMCI_IP back.
+	runCommand([]string{"sed", "-i", "-e", fmt.Sprintf("s/%s/\\$ZP_KUBEMCI_IP/", ipName), "examples/zone-printer/ingress/nginx.yaml"})
+	runCommand([]string{"sed", "-i", "-e", fmt.Sprintf("s/%s/\\$ZP_KUBEMCI_IP/", ipName), "examples/zone-printer/ingress/https-ingress.yaml"})
+}
+
+func testHTTPIngress(project, kubeConfigPath, lbName string) {
+	glog.Infof("Testing HTTP ingress")
 	// Run kubemci create command.
-	kubemciArgs := []string{kubemci_bin, "--ingress=examples/zone-printer/ingress/nginx.yaml", fmt.Sprintf("--gcp-project=%s", project), fmt.Sprintf("--kubeconfig=%s", kubeConfigPath)}
+	kubemciArgs := []string{kubemci, "--ingress=examples/zone-printer/ingress/nginx.yaml", fmt.Sprintf("--gcp-project=%s", project), fmt.Sprintf("--kubeconfig=%s", kubeConfigPath)}
 	createArgs := append(kubemciArgs, []string{"create", lbName}...)
 	if _, err := runCommand(createArgs); err != nil {
-		glog.Fatalf("Error creating kubemci:%v", err)
+		glog.Fatalf("Error running kubemci create: %v", err)
 		return
 	}
-	defer func() {
-		// Delete the mci.
+	deleteFn := func() {
+		glog.Infof("Deleting HTTP ingress")
 		deleteArgs := append(kubemciArgs, []string{"delete", lbName}...)
 		runCommand(deleteArgs)
-	}()
+	}
+	defer deleteFn()
 
 	// Tests
 	// TODO(nikhiljindal): Figure out why is sleep required? get-status should work immediately after create is successful.
 	time.Sleep(5 * time.Second)
 	// Ensure that get-status returns the expected output.
-	getStatusArgs := []string{kubemci_bin, "get-status", lbName, fmt.Sprintf("--gcp-project=%s", project)}
+	getStatusArgs := []string{kubemci, "get-status", lbName, fmt.Sprintf("--gcp-project=%s", project)}
 	output, _ := runCommand(getStatusArgs)
 	glog.Infof("Output from get-status: %s", output)
 	ipAddress := findIPv4(output)
 	glog.Infof("IP Address: %s", ipAddress)
 	// Ensure that the IP address eventually returns 202.
-	if err := waitForIngress(ipAddress); err != nil {
+	if err := waitForIngress(ipAddress, "http"); err != nil {
 		glog.Errorf("error in GET %s: %s", ipAddress, err)
 	}
 	fmt.Println("PASS: got 200 from ingress url")
+	testList(project, ipAddress, lbName)
 
-	listArgs := []string{kubemci_bin, "list", fmt.Sprintf("--gcp-project=%s", project)}
+	// TODO(nikhiljindal): Ensure that the ingress is created and deleted in all
+	// clusters as expected.
+}
+
+func testHTTPSIngress(project, kubeConfigPath, lbName string, clients map[string]kubeclient.Interface) {
+	glog.Infof("Testing HTTPS ingress")
+	// Generate the crt and key.
+	// TODO(nikhiljindal): Generate valid certs instead of using self signed
+	// certs so that we do not need InsecureSkipVerify.
+	certGenArgs := []string{"openssl", "req", "-x509", "-nodes", "-days", "365", "-newkey", "rsa:2048", "-keyout", "tls.key", "-out", "tls.crt", "-subj", "/CN=nginxsvc/O=nginxsv"}
+	runCommand(certGenArgs)
+	// Create the secret in all clusters.
+	for k := range clients {
+		createSecretArgs := []string{"kubectl", "create", "secret", "tls", "tls-secret", "--key", "tls.key", "--cert", "tls.crt", fmt.Sprintf("--context=%s", k)}
+		// create secret may fail if this was setup in a previous run.
+		runCommand(createSecretArgs)
+	}
+
+	// Run kubemci create command.
+	kubemciArgs := []string{kubemci, "--ingress=examples/zone-printer/ingress/https-ingress.yaml", fmt.Sprintf("--gcp-project=%s", project), fmt.Sprintf("--kubeconfig=%s", kubeConfigPath)}
+	createArgs := append(kubemciArgs, []string{"create", lbName}...)
+	if _, err := runCommand(createArgs); err != nil {
+		glog.Fatalf("Error running kubemci create: %v", err)
+		return
+	}
+	deleteFn := func() {
+		glog.Infof("Deleting HTTPS ingress")
+		// Delete the mci and delete the secret.
+		deleteArgs := append(kubemciArgs, []string{"delete", lbName}...)
+		runCommand(deleteArgs)
+		// Delete the secret from all clusters.
+		for k := range clients {
+			deleteSecretArgs := []string{"kubectl", "delete", "secret", "tls-secret", fmt.Sprintf("--context=%s", k)}
+			runCommand(deleteSecretArgs)
+		}
+	}
+	defer deleteFn()
+
+	// Tests
+	// TODO(nikhiljindal): Figure out why is sleep required? get-status should work immediately after create is successful.
+	time.Sleep(5 * time.Second)
+	// Ensure that get-status returns the expected output.
+	getStatusArgs := []string{kubemci, "get-status", lbName, fmt.Sprintf("--gcp-project=%s", project)}
+	output, _ := runCommand(getStatusArgs)
+	glog.Infof("Output from get-status: %s", output)
+	ipAddress := findIPv4(output)
+	glog.Infof("IP Address: %s", ipAddress)
+	// Ensure that the IP address eventually returns 202.
+	if err := waitForIngress(ipAddress, "http"); err != nil {
+		glog.Errorf("error in GET %s: %s", ipAddress, err)
+	}
+	// Ensure that the IP address returns 202 for https as well.
+	if err := waitForIngress(ipAddress, "https"); err != nil {
+		glog.Errorf("error in GET %s: %s", ipAddress, err)
+	}
+	fmt.Println("PASS: got 200 from ingress url")
+	testList(project, ipAddress, lbName)
+
+	// TODO(nikhiljindal): Ensure that the ingress is created and deleted in all
+	// clusters as expected.
+}
+
+// testList tests that the list command returns a load balancer with the given name and ip address.
+func testList(project, ipAddress, lbName string) {
+	listArgs := []string{kubemci, "list", fmt.Sprintf("--gcp-project=%s", project)}
 	listStr, err := runCommand(listArgs)
 	if err != nil {
 		glog.Fatalf("Error listing MCIs: %v", err)
@@ -125,7 +211,4 @@ func RunBasicCreateTest() {
 		glog.Fatalf("Status does not contain lb name (%s) and IP (%s): %s", lbName, ipAddress, listStr)
 	}
 	fmt.Println("PASS: found loadbalancer name and IP in 'list' command.")
-
-	// TODO(nikhiljindal): Ensure that the ingress is created and deleted in all
-	// clusters as expected.
 }


### PR DESCRIPTION
Ref https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/46

Updating the e2e test script to verify an HTTPS ingress.
~~Also fixing a bug in deleting SSL cert in the process.
SSL cert can not be deleted before the target proxy using it is deleted.~~

cc @G-Harmon @csbell 
