### PR TITLE
Fixing a bug in deleting SSL certs

### DIFF
--- a/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
+++ b/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
@@ -224,13 +224,13 @@ func (l *LoadBalancerSyncer) DeleteLoadBalancer(ing *v1beta1.Ingress) error {
 		// Aggregate errors and return all at the end.
 		err = multierror.Append(err, frErr)
 	}
-	if scErr := l.scs.DeleteSSLCert(); scErr != nil {
-		// Aggregate errors and return all at the end.
-		err = multierror.Append(err, scErr)
-	}
 	if tpErr := l.tps.DeleteTargetProxies(); tpErr != nil {
 		// Aggregate errors and return all at the end.
 		err = multierror.Append(err, tpErr)
+	}
+	if scErr := l.scs.DeleteSSLCert(); scErr != nil {
+		// Aggregate errors and return all at the end.
+		err = multierror.Append(err, scErr)
 	}
 	if umErr := l.ums.DeleteURLMap(); umErr != nil {
 		// Aggregate errors and return all at the end.


### PR DESCRIPTION
Forked from https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/pull/100.

Fixing a bug in deleting SSL cert.
SSL cert can not be deleted before the target proxy using it is deleted.

Found while testing https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/pull/100

cc @G-Harmon 