### PR TITLE
Verify that recreating the ingress works as expected

### DIFF
--- a/app/kubemci/pkg/gcp/healthcheck/healthchecksyncer.go
+++ b/app/kubemci/pkg/gcp/healthcheck/healthchecksyncer.go
@@ -259,7 +259,7 @@ func (h *HealthCheckSyncer) desiredHealthCheck(lbName string, port ingressbe.Ser
 		hc.HttpsHealthCheck = &compute.HTTPSHealthCheck{
 			Port:        port.Port, // TODO(nikhiljindal): Allow customization.
 			RequestPath: path,
-			// TODO(G-Harmon): When HTTPS support is added, we likely need to set ProxyHeader, like HTTP does.
+			ProxyHeader: "NONE",
 		}
 		break
 	default:

--- a/test/e2e/cases/basic.go
+++ b/test/e2e/cases/basic.go
@@ -71,6 +71,12 @@ func testHTTPIngress(project, kubeConfigPath, lbName string) {
 	fmt.Println("PASS: got 200 from ingress url")
 	testList(project, ipAddress, lbName)
 
+	// Running create again should not return any error.
+	_, err = createIngress(project, kubeConfigPath, lbName, "examples/zone-printer/ingress/nginx.yaml")
+	if err != nil {
+		glog.Fatalf("Unexpected error in re-creating ingress: %+v", err)
+	}
+
 	// TODO(nikhiljindal): Ensure that the ingress is created and deleted in all
 	// clusters as expected.
 }
@@ -100,6 +106,14 @@ func testHTTPSIngress(project, kubeConfigPath, lbName string, kubectlArgs []stri
 	}
 	fmt.Println("PASS: got 200 from ingress url")
 	testList(project, ipAddress, lbName)
+
+	// Running create again should not return any error.
+	_, err = createIngress(project, kubeConfigPath, lbName, "examples/zone-printer/ingress/https-ingress.yaml")
+	if err != nil {
+		// TODO(nikhiljindal): Change this to unexpected fatal error once
+		// https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/125 is fixed.
+		glog.Infof("Expected error in re-creating https ingress: %+v", err)
+	}
 
 	// TODO(nikhiljindal): Ensure that the ingress is created and deleted in all
 	// clusters as expected.


### PR DESCRIPTION
Updating the test to verify that running kubemci create does not return an error.

This works for HTTP but fails for HTTPS due to https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/125

cc @G-Harmon 