### PR TITLE
Remove duplicate updating existing resource messages

### DIFF
--- a/app/kubemci/pkg/gcp/backendservice/backendservicesyncer.go
+++ b/app/kubemci/pkg/gcp/backendservice/backendservicesyncer.go
@@ -137,7 +137,6 @@ func (b *BackendServiceSyncer) ensureBackendService(lbName string, port ingressb
 		if forceUpdate {
 			// TODO(G-Harmon): Figure out how to properly calculate the fp. Using Sha256 returned a googleapi error.
 			desiredBE.Fingerprint = existingBE.Fingerprint
-			fmt.Println("Updating existing backend service", name, "to match the desired state (since --force specified)")
 			return b.updateBackendService(desiredBE)
 		} else {
 			// TODO(G-Harmon): Show diff to user and prompt yes/no for overwriting.
@@ -157,6 +156,7 @@ func (b *BackendServiceSyncer) ensureBackendService(lbName string, port ingressb
 // updateBackendService updates the backend service and returns the updated backend service.
 func (b *BackendServiceSyncer) updateBackendService(desiredBE *compute.BackendService) (*compute.BackendService, error) {
 	name := desiredBE.Name
+	fmt.Println("Updating existing backend service", name, "to match the desired state")
 	err := b.bsp.UpdateGlobalBackendService(desiredBE)
 	if err != nil {
 		// TODO(G-Harmon): Errors should probably go to STDERR.

--- a/app/kubemci/pkg/gcp/firewallrule/firewallrulesyncer.go
+++ b/app/kubemci/pkg/gcp/firewallrule/firewallrulesyncer.go
@@ -100,7 +100,6 @@ func (s *FirewallRuleSyncer) ensureFirewallRule(lbName string, ports []ingressbe
 			return nil
 		}
 		if forceUpdate {
-			fmt.Println("Updating existing firewall rule to match the desired state (since --force specified)")
 			return s.updateFirewallRule(desiredFW)
 		} else {
 			fmt.Println("Will not overwrite a differing firewall rule without the --force flag.")
@@ -116,6 +115,7 @@ func (s *FirewallRuleSyncer) ensureFirewallRule(lbName string, ports []ingressbe
 // updateFirewallRule updates the firewall rule and returns the updated firewall rule.
 func (s *FirewallRuleSyncer) updateFirewallRule(desiredFR *compute.Firewall) error {
 	name := desiredFR.Name
+	fmt.Println("Updating existing firewall rule", name, "to match the desired state")
 	err := s.fwp.UpdateFirewall(desiredFR)
 	if err != nil {
 		fmt.Println("Error updating firewall:", err)

--- a/app/kubemci/pkg/gcp/forwardingrule/forwardingrulesyncer.go
+++ b/app/kubemci/pkg/gcp/forwardingrule/forwardingrulesyncer.go
@@ -92,7 +92,6 @@ func (s *ForwardingRuleSyncer) ensureForwardingRule(lbName, ipAddress, targetPro
 			return nil
 		}
 		if forceUpdate {
-			fmt.Println("Updating existing forwarding rule", name, "to match the desired state")
 			return s.updateForwardingRule(existingFR, desiredFR)
 		} else {
 			fmt.Println("Will not overwrite this differing Forwarding Rule without the --force flag")
@@ -207,6 +206,7 @@ func (s *ForwardingRuleSyncer) ListLoadBalancerStatuses() ([]status.LoadBalancer
 
 func (s *ForwardingRuleSyncer) updateForwardingRule(existingFR, desiredFR *compute.ForwardingRule) error {
 	name := desiredFR.Name
+	fmt.Println("Updating existing forwarding rule", name, "to match the desired state")
 	// We do not have an UpdateForwardingRule method.
 	// If target proxy link is the only thing that is different, then we can call SetProxyForGlobalForwardingRule.
 	// Else, we need to delete the existing rule and create a new one.

--- a/app/kubemci/pkg/gcp/healthcheck/healthchecksyncer.go
+++ b/app/kubemci/pkg/gcp/healthcheck/healthchecksyncer.go
@@ -178,7 +178,6 @@ func (h *HealthCheckSyncer) ensureHealthCheck(lbName string, port ingressbe.Serv
 			return existingHC, nil
 		}
 		if forceUpdate {
-			fmt.Println("Updating existing health check", name, "to match the desired state")
 			return h.updateHealthCheck(&desiredHC)
 		} else {
 			// TODO(G-Harmon): prompt yes/no for overwriting.

--- a/app/kubemci/pkg/gcp/sslcert/sslcertsyncer.go
+++ b/app/kubemci/pkg/gcp/sslcert/sslcertsyncer.go
@@ -95,7 +95,6 @@ func (s *SSLCertSyncer) ensureSecretSSLCert(lbName string, ing *v1beta1.Ingress,
 		}
 		fmt.Println("Existing SSL certificate does not match the desired certificate. Note that updating existing certificate will cause downtime.")
 		if forceUpdate {
-			fmt.Println("Updating existing SSL cert", name, "to match the desired state")
 			return s.updateSSLCert(desiredCert)
 		} else {
 			fmt.Println("Will not overwrite this differing SSL cert without the --force flag.")

--- a/app/kubemci/pkg/gcp/targetproxy/targetproxysyncer.go
+++ b/app/kubemci/pkg/gcp/targetproxy/targetproxysyncer.go
@@ -116,7 +116,6 @@ func (s *TargetProxySyncer) ensureHttpProxy(lbName, umLink string, forceUpdate b
 			return existingHttpProxy.SelfLink, nil
 		}
 		if forceUpdate {
-			fmt.Println("Updating existing target HTTP proxy", name, "to match the desired state")
 			return s.updateHttpTargetProxy(desiredHttpProxy)
 		} else {
 			fmt.Println("Will not overwrite this differing Target HTTP Proxy without the --force flag")

--- a/app/kubemci/pkg/gcp/urlmap/urlmapsyncer.go
+++ b/app/kubemci/pkg/gcp/urlmap/urlmapsyncer.go
@@ -86,7 +86,6 @@ func (s *URLMapSyncer) EnsureURLMap(lbName string, ing *v1beta1.Ingress, beMap b
 			return existingUM.SelfLink, nil
 		}
 		if forceUpdate {
-			fmt.Println("Updating existing URL Map", name, "to match the desired state")
 			return s.updateURLMap(desiredUM)
 		} else {
 			fmt.Println("Will not overwrite this differing URL Map without the --force flag.")


### PR DESCRIPTION
We log "Updating existing resource" message twice - once before calling updateResource method and then again in the updateResource method.
Removing the call before calling the method and making it consistent for all resources.

cc @G-Harmon 