### PR TITLE
Adding code to set the right network name while creating firewall rules

### DIFF
--- a/app/kubemci/pkg/gcp/instances/fake_instancegetter.go
+++ b/app/kubemci/pkg/gcp/instances/fake_instancegetter.go
@@ -12,22 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package networktags
+package instances
 
-func NewFakeNetworkTagsGetter(tags []string) NetworkTagsGetterInterface {
-	return &FakeNetworkTagsGetter{
-		tags: tags,
-	}
+import (
+	compute "google.golang.org/api/compute/v1"
+)
+
+var FakeInstance = &compute.Instance{
+	Name: "fake-instance",
+	Zone: "my-zone",
+	Tags: &compute.Tags{
+		Items: []string{"fake-tag"},
+	},
 }
 
-// FakeNetworkTagsGetter to be used for tests.
-type FakeNetworkTagsGetter struct {
-	tags []string
+func NewFakeInstanceGetter() InstanceGetterInterface {
+	return &FakeInstanceGetter{}
 }
 
-// Ensure this implements NetworkTagsGetterInterface
-var _ NetworkTagsGetterInterface = &FakeNetworkTagsGetter{}
+// FakeInstanceGetter to be used for tests.
+type FakeInstanceGetter struct {
+}
 
-func (g *FakeNetworkTagsGetter) GetNetworkTags(igUrl string) ([]string, error) {
-	return g.tags, nil
+// Ensure this implements InstanceGetterInterface
+var _ InstanceGetterInterface = &FakeInstanceGetter{}
+
+func (g *FakeInstanceGetter) GetInstance(igUrl string) (*compute.Instance, error) {
+	return FakeInstance, nil
 }

--- a/app/kubemci/pkg/gcp/instances/instancegetter.go
+++ b/app/kubemci/pkg/gcp/instances/instancegetter.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package networktags
+package instances
 
 import (
 	"context"
@@ -25,27 +25,27 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/utils"
 )
 
-func NewNetworkTagsGetter(projectID string) (NetworkTagsGetterInterface, error) {
+func NewInstanceGetter(projectID string) (InstanceGetterInterface, error) {
 	ctx := context.Background()
 	client, err := google.DefaultClient(ctx, compute.CloudPlatformScope)
 	if err != nil {
 		return nil, fmt.Errorf("error in instantiating GCP client: %s", err)
 	}
-	return &NetworkTagsGetter{
+	return &InstanceGetter{
 		client:       client,
 		gcpProjectID: projectID,
 	}, nil
 }
 
-type NetworkTagsGetter struct {
+type InstanceGetter struct {
 	gcpProjectID string
 	client       *http.Client
 }
 
-// Ensure this implements NetworkTagsGetterInterface
-var _ NetworkTagsGetterInterface = &NetworkTagsGetter{}
+// Ensure this implements InstanceGetterInterface
+var _ InstanceGetterInterface = &InstanceGetter{}
 
-func (g *NetworkTagsGetter) GetNetworkTags(igUrl string) ([]string, error) {
+func (g *InstanceGetter) GetInstance(igUrl string) (*compute.Instance, error) {
 	service, err := compute.New(g.client)
 	if err != nil {
 		return nil, fmt.Errorf("error in instantiating GCP client: %s", err)
@@ -72,8 +72,5 @@ func (g *NetworkTagsGetter) GetNetworkTags(igUrl string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error in fetching instance %s/%s: %s", iZone, iName, err)
 	}
-	if len(instance.Tags.Items) == 0 {
-		return nil, fmt.Errorf("no network tag found on instance %s/%s", iZone, iName)
-	}
-	return instance.Tags.Items, nil
+	return instance, nil
 }

--- a/app/kubemci/pkg/gcp/instances/interfaces.go
+++ b/app/kubemci/pkg/gcp/instances/interfaces.go
@@ -12,11 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-package networktags
+package instances
 
-// Interface to fetch network tags from GCE instances.
+import (
+	compute "google.golang.org/api/compute/v1"
+)
+
+// Interface to fetch GCE instances.
 // TODO(nikhiljindal): Move this logic to gce cloudprovider in kubernetes/kubernetes.
-type NetworkTagsGetterInterface interface {
-	// Returns all network tags of an instance in the given instance group.
-	GetNetworkTags(igUrl string) ([]string, error)
+type InstanceGetterInterface interface {
+	// Returns an instance in the given instance group.
+	// There is no guarantee regarding which instance is returned.
+	// Calling this multiple times for the same instance group can return different instances.
+	GetInstance(igUrl string) (*compute.Instance, error)
 }

--- a/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
+++ b/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
@@ -41,8 +41,8 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/firewallrule"
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/forwardingrule"
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/healthcheck"
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/instances"
 	utilsnamer "github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/namer"
-	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/networktags"
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/sslcert"
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/status"
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/targetproxy"
@@ -86,7 +86,7 @@ type LoadBalancerSyncer struct {
 func NewLoadBalancerSyncer(lbName string, clients map[string]kubeclient.Interface, cloud *gce.GCECloud, gcpProjectId string) (*LoadBalancerSyncer, error) {
 
 	namer := utilsnamer.NewNamer(MciPrefix, lbName)
-	ntg, err := networktags.NewNetworkTagsGetter(gcpProjectId)
+	ig, err := instances.NewInstanceGetter(gcpProjectId)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func NewLoadBalancerSyncer(lbName string, clients map[string]kubeclient.Interfac
 		ums:     urlmap.NewURLMapSyncer(namer, cloud),
 		tps:     targetproxy.NewTargetProxySyncer(namer, cloud),
 		frs:     forwardingrule.NewForwardingRuleSyncer(namer, cloud),
-		fws:     firewallrule.NewFirewallRuleSyncer(namer, cloud, ntg),
+		fws:     firewallrule.NewFirewallRuleSyncer(namer, cloud, ig),
 		scs:     sslcert.NewSSLCertSyncer(namer, cloud),
 		clients: clients,
 		igp:     cloud,


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/121

Renamed NetworkTagsGetter to InstanceGetter so that FirewallRuleSyncer can use it to fetch instances and then use the fetched instances to get both network tags and network name. This way we dont fetch instances twice.

cc @G-Harmon @nicksardo @csbell

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/137)
<!-- Reviewable:end -->
