### PR TITLE
Recreating HTTPS ingress should work without error

### DIFF
--- a/app/kubemci/pkg/gcp/sslcert/sslcertsyncer.go
+++ b/app/kubemci/pkg/gcp/sslcert/sslcertsyncer.go
@@ -170,8 +170,10 @@ func sslCertMatches(desiredCert, existingCert compute.SslCertificate) bool {
 	existingCert.Id = 0
 	existingCert.SelfLink = ""
 
+	// Private key is write only, so we compare the certificate alone.
+	// We are assuming that no one will change just the key.
 	// NOTE: We do not print the diff, to not leak the certificate.
-	return reflect.DeepEqual(existingCert, desiredCert)
+	return reflect.DeepEqual(existingCert.Certificate, desiredCert.Certificate)
 }
 
 func (s *SSLCertSyncer) desiredSSLCert(lbName string, ing *v1beta1.Ingress, client kubeclient.Interface) (*compute.SslCertificate, error) {

--- a/test/e2e/cases/basic.go
+++ b/test/e2e/cases/basic.go
@@ -110,9 +110,7 @@ func testHTTPSIngress(project, kubeConfigPath, lbName string, kubectlArgs []stri
 	// Running create again should not return any error.
 	_, err = createIngress(project, kubeConfigPath, lbName, "examples/zone-printer/ingress/https-ingress.yaml")
 	if err != nil {
-		// TODO(nikhiljindal): Change this to unexpected fatal error once
-		// https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/125 is fixed.
-		glog.Infof("Expected error in re-creating https ingress: %+v", err)
+		glog.Fatalf("Unexpected error in re-creating https ingress: %+v", err)
 	}
 
 	// TODO(nikhiljindal): Ensure that the ingress is created and deleted in all


### PR DESCRIPTION
Fixing the issue where recreating https ingress was failing.

This was happening due to 2 reasons:
* kubemci thought that ingress changed even when it didnt. This was happening because the in cluster ingress had the instance groups annotation. Updated the code to ignore that annotation before comparing the ingresses.
* kubemci thought that SSL cert changed even when it didnt. This was because we were comparing the complete cert, which includes both the cert and the private key. But GCP returns a cert with empty private key (key is write only). Updated the code to compare the certificate only, which is what ingress-gce does as well: https://github.com/kubernetes/ingress-gce/blob/572e8e56a0c6ba15b0eac5ca870416c4c8fdc09c/pkg/loadbalancers/l7.go#L280

cc @csbell @madhusudancs @G-Harmon @bowei