### PR TITLE
Ignore "HTTP not found" errors when deleting GCP resources.

### DIFF
--- a/app/kubemci/pkg/gcp/forwardingrule/forwardingrulesyncer.go
+++ b/app/kubemci/pkg/gcp/forwardingrule/forwardingrulesyncer.go
@@ -107,32 +107,32 @@ func (s *ForwardingRuleSyncer) ensureForwardingRule(lbName, ipAddress, targetPro
 func (s *ForwardingRuleSyncer) DeleteForwardingRules() error {
 	var err error
 	name := s.namer.HttpForwardingRuleName()
-	fmt.Println("Deleting http forwarding rule", name)
+	fmt.Println("Deleting HTTP forwarding rule", name)
 	httpErr := s.frp.DeleteGlobalForwardingRule(name)
 	if httpErr != nil {
 		if utils.IsHTTPErrorCode(httpErr, http.StatusNotFound) {
-			fmt.Println("Http forwarding rule", name, "does not exist. Nothing to delete")
+			fmt.Println("HTTP forwarding rule", name, "does not exist. Nothing to delete")
 		} else {
-			httpErr := fmt.Errorf("error %s in deleting http forwarding rule %s", httpErr, name)
+			httpErr := fmt.Errorf("error %s in deleting HTTP forwarding rule %s", httpErr, name)
 			fmt.Println(httpErr)
 			err = multierror.Append(err, httpErr)
 		}
 	} else {
-		fmt.Println("Http forwarding rule", name, "deleted successfully")
+		fmt.Println("HTTP forwarding rule", name, "deleted successfully")
 	}
 	name = s.namer.HttpsForwardingRuleName()
-	fmt.Println("Deleting https forwarding rule", name)
+	fmt.Println("Deleting HTTPS forwarding rule", name)
 	httpsErr := s.frp.DeleteGlobalForwardingRule(name)
 	if httpsErr != nil {
 		if utils.IsHTTPErrorCode(httpsErr, http.StatusNotFound) {
-			fmt.Println("Https forwarding rule", name, "does not exist. Nothing to delete")
+			fmt.Println("HTTPS forwarding rule", name, "does not exist. Nothing to delete")
 		} else {
-			httpsErr := fmt.Errorf("error %s in deleting https forwarding rule %s", httpsErr, name)
+			httpsErr := fmt.Errorf("error %s in deleting HTTPS forwarding rule %s", httpsErr, name)
 			fmt.Println(httpsErr)
 			err = multierror.Append(err, httpsErr)
 		}
 	} else {
-		fmt.Println("Https forwarding rule", name, "deleted successfully")
+		fmt.Println("HTTPS forwarding rule", name, "deleted successfully")
 	}
 	return err
 }

--- a/app/kubemci/pkg/gcp/sslcert/sslcertsyncer.go
+++ b/app/kubemci/pkg/gcp/sslcert/sslcertsyncer.go
@@ -109,14 +109,20 @@ func (s *SSLCertSyncer) ensureSecretSSLCert(lbName string, ing *v1beta1.Ingress,
 
 func (s *SSLCertSyncer) DeleteSSLCert() error {
 	name := s.namer.SSLCertName()
-	fmt.Println("Deleting ssl cert", name)
+	fmt.Println("Deleting SSL cert", name)
 	err := s.scp.DeleteSslCertificate(name)
-	if err != nil && !utils.IsHTTPErrorCode(err, http.StatusNotFound) {
-		fmt.Println("error", err, "in deleting ssl cert", name)
-		return err
+	if err != nil {
+		if utils.IsHTTPErrorCode(err, http.StatusNotFound) {
+			fmt.Println("SSL cert", name, "does not exist. Nothing to delete")
+			return nil
+		} else {
+			fmt.Println("Error", err, "in deleting SSL cert", name)
+			return err
+		}
+	} else {
+		fmt.Println("SSL cert", name, "deleted successfully")
+		return nil
 	}
-	fmt.Println("ssl cert", name, "deleted successfully")
-	return nil
 }
 
 func (s *SSLCertSyncer) updateSSLCert(desiredCert *compute.SslCertificate) (string, error) {

--- a/app/kubemci/pkg/gcp/urlmap/urlmapsyncer.go
+++ b/app/kubemci/pkg/gcp/urlmap/urlmapsyncer.go
@@ -18,6 +18,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"net/http"
 	"reflect"
 
 	compute "google.golang.org/api/compute/v1"
@@ -103,11 +104,17 @@ func (s *URLMapSyncer) DeleteURLMap() error {
 	fmt.Println("Deleting url map", name)
 	err := s.ump.DeleteUrlMap(name)
 	if err != nil {
-		fmt.Println("error", err, "in deleting url map", name)
-		return err
+		if utils.IsHTTPErrorCode(err, http.StatusNotFound) {
+			fmt.Println("URL map", name, "does not exist. Nothing to delete")
+			return nil
+		} else {
+			fmt.Println("Error", err, "in deleting URL map", name)
+			return err
+		}
+	} else {
+		fmt.Println("URL map", name, "deleted successfully")
+		return nil
 	}
-	fmt.Println("url map", name, "deleted successfully")
-	return nil
 }
 
 func (s *URLMapSyncer) updateURLMap(desiredUM *compute.UrlMap) (string, error) {


### PR DESCRIPTION
ingress-gce recently changed to uniformly return "not found" errors
(instead of sometimes masking them). This change is needed before
revendoring ingress-gce.
Fixes issue #119 

cc @Nicksardo @csbell @nikhiljindal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/140)
<!-- Reviewable:end -->
