### PR TITLE
Adding a remove-clusters command

### DIFF
--- a/app/kubemci/cmd/cmd.go
+++ b/app/kubemci/cmd/cmd.go
@@ -40,6 +40,7 @@ func NewCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 		NewCmdGetStatus(out, err),
 		NewCmdGetVersion(out, err),
 		newCmdList(out, err),
+		newCmdRemoveClusters(out, err),
 	)
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	return rootCmd

--- a/app/kubemci/cmd/remove_clusters.go
+++ b/app/kubemci/cmd/remove_clusters.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2018 Google, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,14 +32,17 @@ import (
 )
 
 var (
-	deleteShortDescription = "Delete a multicluster ingress."
-	deleteLongDescription  = `Delete a multicluster ingress.
+	removeClustersShortDesc = "Remove an existing multicluster ingress from some clusters."
+	removeClustersLongDesc  = `Remove an existing multicluster ingress from some clusters.
 
-	Takes an ingress spec and a list of clusters and deletes the multicluster ingress targetting those clusters.
-	`
+	Takes a load balancer name and a list of clusters and removes the existing multicluster ingress from those clusters.
+	If the clusters have already been deleted, you can run "kubemci create --force" with the updated cluster list to update the
+	load balancer to be restricted to those clusters. That will however not delete the ingress from old clusters (which is fine
+	if the clusters have been deleted already).
+`
 )
 
-type DeleteOptions struct {
+type removeClustersOptions struct {
 	// Name of the YAML file containing ingress spec.
 	IngressFilename string
 	// Path to kubeconfig file.
@@ -49,49 +52,49 @@ type DeleteOptions struct {
 	// Name of the load balancer.
 	// Required.
 	LBName string
-	// Name of the GCP project in which the load balancer should be configured.
-	// Required
-	// TODO(nikhiljindal): This should be optional. Figure it out from gcloud settings.
+	// Name of the GCP project in which the load balancer is configured.
 	GCPProject string
+	// Overwrite values when they differ from what's requested. If
+	// the resource does not exist, or is already the correct
+	// value, then 'force' is a no-op.
+	ForceUpdate bool
 	// Name of the namespace for the ingress when none is provided (mismatch of option with spec causes an error).
 	// Optional.
 	Namespace string
 }
 
-func NewCmdDelete(out, err io.Writer) *cobra.Command {
-	var options DeleteOptions
-
+func newCmdRemoveClusters(out, err io.Writer) *cobra.Command {
+	var options removeClustersOptions
 	cmd := &cobra.Command{
-		Use:   "delete [lbname]",
-		Short: deleteShortDescription,
-		Long:  deleteLongDescription,
-		// TODO(nikhiljindal): Add an example.
+		Use:   "remove-clusters",
+		Short: removeClustersShortDesc,
+		Long:  removeClustersLongDesc,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := validateDeleteArgs(&options, args); err != nil {
+			if err := validateRemoveClustersArgs(&options, args); err != nil {
 				fmt.Println(err)
 				return
 			}
-			if err := runDelete(&options, args); err != nil {
-				fmt.Println("Error in deleting load balancer:", err)
+			if err := runRemoveClusters(&options, args); err != nil {
+				fmt.Println("Error removing clusters:", err)
+				return
 			}
 		},
 	}
-	addDeleteFlags(cmd, &options)
+	addRemoveClustersFlags(cmd, &options)
 	return cmd
 }
 
-func addDeleteFlags(cmd *cobra.Command, options *DeleteOptions) error {
+func addRemoveClustersFlags(cmd *cobra.Command, options *removeClustersOptions) error {
 	cmd.Flags().StringVarP(&options.IngressFilename, "ingress", "i", options.IngressFilename, "[required] filename containing ingress spec")
 	cmd.Flags().StringVarP(&options.KubeconfigFilename, "kubeconfig", "k", options.KubeconfigFilename, "[required] path to kubeconfig file")
-	cmd.Flags().StringSliceVar(&options.KubeContexts, "kubecontexts", options.KubeContexts, "[optional] contexts in the kubeconfig file to delete the ingress from")
-	// TODO(nikhiljindal): Add a short flag "-p" if it seems useful.
-	cmd.Flags().StringVarP(&options.GCPProject, "gcp-project", "", options.GCPProject, "[optional] name of the gcp project. Is fetched using gcloud config get-value project if unset here")
+	cmd.Flags().StringSliceVar(&options.KubeContexts, "kubecontexts", options.KubeContexts, "[optional] contexts in the kubeconfig file to remove the ingress from")
+	cmd.Flags().StringVarP(&options.GCPProject, "gcp-project", "", options.GCPProject, "[required] name of the gcp project")
+	cmd.Flags().BoolVarP(&options.ForceUpdate, "force", "f", options.ForceUpdate, "[optional] overwrite existing settings if they are different")
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", options.Namespace, "[optional] namespace for the ingress only if left unspecified by ingress spec")
-	// TODO Add a verbose flag that turns on glog logging.
 	return nil
 }
 
-func validateDeleteArgs(options *DeleteOptions, args []string) error {
+func validateRemoveClustersArgs(options *removeClustersOptions, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("unexpected args: %v. Expected one arg as name of load balancer.", args)
 	}
@@ -112,7 +115,8 @@ func validateDeleteArgs(options *DeleteOptions, args []string) error {
 	return nil
 }
 
-func runDelete(options *DeleteOptions, args []string) error {
+// runRemoveClusters removes the given load balancer from the given list of clusters.
+func runRemoveClusters(options *removeClustersOptions, args []string) error {
 	options.LBName = args[0]
 
 	// Unmarshal the YAML into ingress struct.
@@ -122,17 +126,12 @@ func runDelete(options *DeleteOptions, args []string) error {
 	}
 	cloudInterface, err := cloudinterface.NewGCECloudInterface(options.GCPProject)
 	if err != nil {
-		return fmt.Errorf("error in creating cloud interface: %s", err)
-	}
-
-	// Get clients for all clusters
-	clients, err := kubeutils.GetClients(options.KubeconfigFilename, options.KubeContexts)
-	if err != nil {
+		err := fmt.Errorf("error in creating cloud interface: %s", err)
+		fmt.Println(err)
 		return err
 	}
-
-	// Delete ingress resource in clusters
-	err = ingress.NewIngressSyncer().DeleteIngress(&ing, clients)
+	// Get clients for all clusters
+	clients, err := kubeutils.GetClients(options.KubeconfigFilename, options.KubeContexts)
 	if err != nil {
 		return err
 	}
@@ -141,8 +140,14 @@ func runDelete(options *DeleteOptions, args []string) error {
 	if err != nil {
 		return err
 	}
-	if delErr := lbs.DeleteLoadBalancer(&ing); delErr != nil {
+	if delErr := lbs.RemoveFromClusters(&ing, clients, options.ForceUpdate); delErr != nil {
 		err = multierror.Append(err, delErr)
+	}
+
+	// Delete ingress resource from clusters
+	err = ingress.NewIngressSyncer().DeleteIngress(&ing, clients)
+	if err != nil {
+		return err
 	}
 	return err
 }

--- a/app/kubemci/pkg/gcp/backendservice/backendservicesyncer.go
+++ b/app/kubemci/pkg/gcp/backendservice/backendservicesyncer.go
@@ -89,6 +89,38 @@ func (b *BackendServiceSyncer) DeleteBackendServices(ports []ingressbe.ServicePo
 	return nil
 }
 
+// See interface for comment.
+func (b *BackendServiceSyncer) RemoveFromClusters(ports []ingressbe.ServicePort, removeIGLinks []string) error {
+	fmt.Println("Removing backend services from clusters")
+	var err error
+	for _, p := range ports {
+		if beErr := b.removeFromClusters(p, removeIGLinks); beErr != nil {
+			beErr = fmt.Errorf("Error %s in removing backend service for port %v", beErr, p)
+			fmt.Printf("Error in removing backend service for port %v: %v. Continuing.\n", p, beErr)
+			// Try removing backend services for all ports and return all errors at once.
+			err = multierror.Append(err, beErr)
+			continue
+		}
+	}
+	return err
+}
+
+func (b *BackendServiceSyncer) removeFromClusters(port ingressbe.ServicePort, removeIGLinks []string) error {
+	name := b.namer.BeServiceName(port.Port)
+
+	existingBE, err := b.bsp.GetGlobalBackendService(name)
+	if err != nil {
+		err := fmt.Errorf("error in fetching existing backend service %s: %s", name, err)
+		fmt.Println(err)
+		return err
+	}
+	// Remove clusters from the backend service.
+	desiredBE := b.desiredBackendServiceWithoutClusters(existingBE, removeIGLinks)
+	glog.V(5).Infof("Existing backend service: %v\n, desired: %v\n", *existingBE, *desiredBE)
+	_, err = b.updateBackendService(desiredBE)
+	return err
+}
+
 func (b *BackendServiceSyncer) deleteBackendService(port ingressbe.ServicePort) error {
 	name := b.namer.BeServiceName(port.Port)
 	glog.V(2).Infof("Deleting backend service %s", name)
@@ -236,6 +268,24 @@ func (b *BackendServiceSyncer) desiredBackendService(lbName string, port ingress
 		SessionAffinity:     "NONE",
 		TimeoutSec:          30,
 	}
+}
+
+func (b *BackendServiceSyncer) desiredBackendServiceWithoutClusters(existingBE *compute.BackendService, removeIGLinks []string) *compute.BackendService {
+	// Compute the backends to be removed.
+	removeBackends := desiredBackends(removeIGLinks)
+	removeBackendsMap := map[string]bool{}
+	for _, v := range removeBackends {
+		removeBackendsMap[v.Group] = true
+	}
+	var newBackends []*compute.Backend
+	for _, v := range existingBE.Backends {
+		if !removeBackendsMap[v.Group] {
+			newBackends = append(newBackends, v)
+		}
+	}
+	desiredBE := existingBE
+	desiredBE.Backends = newBackends
+	return desiredBE
 }
 
 func desiredBackends(igLinks []string) []*compute.Backend {

--- a/app/kubemci/pkg/gcp/backendservice/backendservicesyncer.go
+++ b/app/kubemci/pkg/gcp/backendservice/backendservicesyncer.go
@@ -270,6 +270,7 @@ func (b *BackendServiceSyncer) desiredBackendService(lbName string, port ingress
 	}
 }
 
+// desiredBackendServiceWithoutClusters returns the desired backend service after removing the given instance groups from the given existing backend service.
 func (b *BackendServiceSyncer) desiredBackendServiceWithoutClusters(existingBE *compute.BackendService, removeIGLinks []string) *compute.BackendService {
 	// Compute the backends to be removed.
 	removeBackends := desiredBackends(removeIGLinks)

--- a/app/kubemci/pkg/gcp/backendservice/backendservicesyncer_test.go
+++ b/app/kubemci/pkg/gcp/backendservice/backendservicesyncer_test.go
@@ -217,8 +217,8 @@ func TestRemoveFromClusters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected nil error, actual: %v", err)
 	}
-	if len(be.Backends) != 1 {
-		t.Fatalf("expected the backend service to have 1 backend for ig: %s, actual: %v", ig2Link, be.Backends)
+	if len(be.Backends) != 1 || be.Backends[0].Group != ig1Link {
+		t.Fatalf("expected the backend service to have 1 backend for ig: %s, actual: %v", ig1Link, be.Backends)
 	}
 
 	// Cleanup

--- a/app/kubemci/pkg/gcp/backendservice/fake_backendservicesyncer.go
+++ b/app/kubemci/pkg/gcp/backendservice/fake_backendservicesyncer.go
@@ -61,3 +61,8 @@ func (h *FakeBackendServiceSyncer) DeleteBackendServices(ports []ingressbe.Servi
 	h.EnsuredBackendServices = nil
 	return nil
 }
+
+func (h *FakeBackendServiceSyncer) RemoveFromClusters(ports []ingressbe.ServicePort, removeIGLinks []string) error {
+	// TODO: Implement this.
+	return nil
+}

--- a/app/kubemci/pkg/gcp/backendservice/fake_backendservicesyncer.go
+++ b/app/kubemci/pkg/gcp/backendservice/fake_backendservicesyncer.go
@@ -63,6 +63,26 @@ func (h *FakeBackendServiceSyncer) DeleteBackendServices(ports []ingressbe.Servi
 }
 
 func (h *FakeBackendServiceSyncer) RemoveFromClusters(ports []ingressbe.ServicePort, removeIGLinks []string) error {
-	// TODO: Implement this.
+	// Convert array to maps for easier lookups.
+	affectedPorts := make(map[int64]bool, len(ports))
+	for _, v := range ports {
+		affectedPorts[v.Port] = true
+	}
+	removeLinks := make(map[string]bool, len(removeIGLinks))
+	for _, v := range removeIGLinks {
+		removeLinks[v] = true
+	}
+	for _, v := range h.EnsuredBackendServices {
+		if _, has := affectedPorts[v.Port.Port]; !has {
+			continue
+		}
+		newIGLinks := []string{}
+		for _, ig := range v.IGLinks {
+			if _, has := removeLinks[ig]; !has {
+				newIGLinks = append(newIGLinks, ig)
+			}
+		}
+		v.IGLinks = newIGLinks
+	}
 	return nil
 }

--- a/app/kubemci/pkg/gcp/backendservice/interfaces.go
+++ b/app/kubemci/pkg/gcp/backendservice/interfaces.go
@@ -37,4 +37,6 @@ type BackendServiceSyncerInterface interface {
 	EnsureBackendService(lbName string, ports []ingressbe.ServicePort, hcMap healthcheck.HealthChecksMap, npMap NamedPortsMap, igLinks []string, forceUpdate bool) (BackendServicesMap, error)
 	// DeleteBackendServices deletes all backend services that would have been created by EnsureBackendService.
 	DeleteBackendServices(ports []ingressbe.ServicePort) error
+	// RemoveFromClusters removes the clusters corresponding to the given removeIGLinks from the existing backend services corresponding to the given ports.
+	RemoveFromClusters(ports []ingressbe.ServicePort, removeIGLinks []string) error
 }

--- a/app/kubemci/pkg/gcp/firewallrule/fake_firewallrulesyncer.go
+++ b/app/kubemci/pkg/gcp/firewallrule/fake_firewallrulesyncer.go
@@ -50,3 +50,20 @@ func (h *FakeFirewallRuleSyncer) DeleteFirewallRules() error {
 	h.EnsuredFirewallRules = nil
 	return nil
 }
+
+func (h *FakeFirewallRuleSyncer) RemoveFromClusters(lbName string, removeIGLinks map[string][]string) error {
+	for _, v := range h.EnsuredFirewallRules {
+		if v.LBName != lbName {
+			continue
+		}
+		newIGLinks := map[string][]string{}
+		for clusterName, igValues := range v.IGLinks {
+			if _, has := removeIGLinks[clusterName]; !has {
+				newIGLinks[clusterName] = igValues
+			}
+		}
+		v.IGLinks = newIGLinks
+	}
+	h.EnsuredFirewallRules = nil
+	return nil
+}

--- a/app/kubemci/pkg/gcp/firewallrule/fake_firewallrulesyncer.go
+++ b/app/kubemci/pkg/gcp/firewallrule/fake_firewallrulesyncer.go
@@ -64,6 +64,5 @@ func (h *FakeFirewallRuleSyncer) RemoveFromClusters(lbName string, removeIGLinks
 		}
 		v.IGLinks = newIGLinks
 	}
-	h.EnsuredFirewallRules = nil
 	return nil
 }

--- a/app/kubemci/pkg/gcp/firewallrule/firewallrulesyncer.go
+++ b/app/kubemci/pkg/gcp/firewallrule/firewallrulesyncer.go
@@ -93,7 +93,7 @@ func (s *FirewallRuleSyncer) RemoveFromClusters(lbName string, removeIGLinks map
 	glog.V(5).Infof("Received instance groups: %v", removeIGLinks)
 	err := s.removeFromClusters(lbName, removeIGLinks)
 	if err != nil {
-		return fmt.Errorf("Error %s in removing clusters from firewall rule", err)
+		return fmt.Errorf("Error in removing clusters from firewall rule: %s", err)
 	}
 	return nil
 }
@@ -254,7 +254,8 @@ func (s *FirewallRuleSyncer) desiredFirewallRuleWithoutClusters(existingFW *comp
 	// rather than removing the ones for old clusters.
 	// But we do not want to change existing tags for clusters that are already working.
 	// Ideally network tags should only be appended to, so this should not be a problem.
-	// TODO(nikhiljindal): Fix this if it becomes a problem.
+	// TODO(nikhiljindal): Fix this if it becomes a problem:
+	// https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/147
 	targetTags, err := s.getTargetTags(instances)
 	if err != nil {
 		return nil, err

--- a/app/kubemci/pkg/gcp/firewallrule/firewallrulesyncer.go
+++ b/app/kubemci/pkg/gcp/firewallrule/firewallrulesyncer.go
@@ -87,6 +87,34 @@ func (s *FirewallRuleSyncer) DeleteFirewallRules() error {
 	}
 }
 
+// See interface comment.
+func (s *FirewallRuleSyncer) RemoveFromClusters(lbName string, removeIGLinks map[string][]string) error {
+	fmt.Println("Removing clusters from firewall rule")
+	glog.V(5).Infof("Received instance groups: %v", removeIGLinks)
+	err := s.removeFromClusters(lbName, removeIGLinks)
+	if err != nil {
+		return fmt.Errorf("Error %s in removing clusters from firewall rule", err)
+	}
+	return nil
+}
+
+func (s *FirewallRuleSyncer) removeFromClusters(lbName string, removeIGLinks map[string][]string) error {
+	name := s.namer.FirewallRuleName()
+	existingFW, err := s.fwp.GetFirewall(name)
+	if err != nil {
+		err := fmt.Errorf("error in fetching existing firewall rule %s: %s", name, err)
+		fmt.Println(err)
+		return err
+	}
+	// Remove clusters from the firewall rule.
+	desiredFW, err := s.desiredFirewallRuleWithoutClusters(existingFW, removeIGLinks)
+	if err != nil {
+		return err
+	}
+	glog.V(5).Infof("Existing firewall rule: %v\n, desired firewall rule: %v\n", *existingFW, *desiredFW)
+	return s.updateFirewallRule(desiredFW)
+}
+
 // ensureFirewallRule ensures that the required firewall rule exists for the given ports.
 // Does nothing if it exists already, else creates a new one.
 func (s *FirewallRuleSyncer) ensureFirewallRule(lbName string, ports []ingressbe.ServicePort, igLinks map[string][]string, forceUpdate bool) error {
@@ -213,6 +241,45 @@ func (s *FirewallRuleSyncer) desiredFirewallRule(lbName string, ports []ingressb
 		Direction:  "INGRESS",
 		Network:    network,
 	}, nil
+}
+
+func (s *FirewallRuleSyncer) desiredFirewallRuleWithoutClusters(existingFW *compute.Firewall, removeIGLinks map[string][]string) (*compute.Firewall, error) {
+	// Compute the target tags that need to be removed for the given instance groups.
+	instances, err := s.getInstances(removeIGLinks)
+	if err != nil {
+		return nil, err
+	}
+	// This assumes that the ordering of target tags has not changed on these instances.
+	// A potential solution to that problem is to recompute the target tags for the existing clusters,
+	// rather than removing the ones for old clusters.
+	// But we do not want to change existing tags for clusters that are already working.
+	// Ideally network tags should only be appended to, so this should not be a problem.
+	// TODO(nikhiljindal): Fix this if it becomes a problem.
+	targetTags, err := s.getTargetTags(instances)
+	if err != nil {
+		return nil, err
+	}
+	existingTargetTags := existingFW.TargetTags
+	glog.V(3).Infof("Removing target tags %q from existing target tags %q", targetTags, existingTargetTags)
+	// Compute target tags as existingTargetTags - targetTags.
+	// Note: This assumes that all target tags are unique and no two instances from different clusters share the same target tag.
+	// If that is false, then opening a firewall rule for instances in one cluster will open instances from other cluster as well.
+	// Similarly, removing one cluster will remove the other cluster as well.
+	removeTags := map[string]bool{}
+	for _, v := range targetTags {
+		removeTags[v] = true
+	}
+	var newTargetTags []string
+	for _, v := range existingTargetTags {
+		if !removeTags[v] {
+			newTargetTags = append(newTargetTags, v)
+		}
+	}
+	// Sort the tags to have a deterministic order.
+	sort.Strings(newTargetTags)
+	desiredFW := existingFW
+	desiredFW.TargetTags = newTargetTags
+	return desiredFW, nil
 }
 
 // Returns an array of instances, with an instance from each cluster.

--- a/app/kubemci/pkg/gcp/firewallrule/interfaces.go
+++ b/app/kubemci/pkg/gcp/firewallrule/interfaces.go
@@ -25,4 +25,6 @@ type FirewallRuleSyncerInterface interface {
 	EnsureFirewallRule(lbName string, ports []ingressbe.ServicePort, igLinks map[string][]string, forceUpdate bool) error
 	// DeleteFirewallRules deletes all firewall rules that would have been created by EnsureFirewallRule.
 	DeleteFirewallRules() error
+	// RemoveFromClusters removes the clusters corresponding to the given instance groups from the firewall rule.
+	RemoveFromClusters(lbName string, removeIGLinks map[string][]string) error
 }

--- a/app/kubemci/pkg/gcp/forwardingrule/fake_forwardingrulesyncer.go
+++ b/app/kubemci/pkg/gcp/forwardingrule/fake_forwardingrulesyncer.go
@@ -94,6 +94,18 @@ func (f *FakeForwardingRuleSyncer) ListLoadBalancerStatuses() ([]status.LoadBala
 }
 
 func (f *FakeForwardingRuleSyncer) RemoveClustersFromStatus(clusters []string) error {
-	// TODO: Implement this.
+	removeClusters := make(map[string]bool, len(clusters))
+	for _, c := range clusters {
+		removeClusters[c] = true
+	}
+	for i, fr := range f.EnsuredForwardingRules {
+		newClusters := []string{}
+		for _, c := range fr.Clusters {
+			if _, has := removeClusters[c]; !has {
+				newClusters = append(newClusters, c)
+			}
+		}
+		f.EnsuredForwardingRules[i].Clusters = newClusters
+	}
 	return nil
 }

--- a/app/kubemci/pkg/gcp/forwardingrule/fake_forwardingrulesyncer.go
+++ b/app/kubemci/pkg/gcp/forwardingrule/fake_forwardingrulesyncer.go
@@ -92,3 +92,8 @@ func (f *FakeForwardingRuleSyncer) ListLoadBalancerStatuses() ([]status.LoadBala
 	}
 	return ret, nil
 }
+
+func (f *FakeForwardingRuleSyncer) RemoveClustersFromStatus(clusters []string) error {
+	// TODO: Implement this.
+	return nil
+}

--- a/app/kubemci/pkg/gcp/forwardingrule/forwardingrulesyncer.go
+++ b/app/kubemci/pkg/gcp/forwardingrule/forwardingrulesyncer.go
@@ -207,7 +207,7 @@ func (s *ForwardingRuleSyncer) ListLoadBalancerStatuses() ([]status.LoadBalancer
 // See interface for comment.
 func (s *ForwardingRuleSyncer) RemoveClustersFromStatus(clusters []string) error {
 	// Update HTTPS status first and then HTTP.
-	// This ensures that get-status returns the correct status even if HTTPS is updated but updating HTTP fails.
+	// This ensures that get-status returns the old status until both HTTPS and HTTP forwarding rules are updated.
 	// This is because get-status reads from HTTP if it exists.
 	// Also note that it continues silently if either HTTP or HTTPS forwarding rules do not exist.
 	if err := s.removeClustersFromStatus("https", s.namer.HttpsForwardingRuleName(), clusters); err != nil {
@@ -216,7 +216,7 @@ func (s *ForwardingRuleSyncer) RemoveClustersFromStatus(clusters []string) error
 	return s.removeClustersFromStatus("http", s.namer.HttpForwardingRuleName(), clusters)
 }
 
-// ensureForwardingRule ensures a forwarding rule exists as per the given input parameters.
+// removeClustersFromStatus removes the given list of clusters from the existing forwarding rule with the given name.
 func (s *ForwardingRuleSyncer) removeClustersFromStatus(httpProtocol, name string, clusters []string) error {
 	fmt.Println("Removing clusters", clusters, "from", httpProtocol, "forwarding rule")
 	existingFR, err := s.frp.GetGlobalForwardingRule(name)

--- a/app/kubemci/pkg/gcp/forwardingrule/interfaces.go
+++ b/app/kubemci/pkg/gcp/forwardingrule/interfaces.go
@@ -31,8 +31,11 @@ type ForwardingRuleSyncerInterface interface {
 	// DeleteForwardingRules deletes the forwarding rules that
 	// EnsureHttpForwardingRule and EnsureHttpsForwardingRule would have created.
 	DeleteForwardingRules() error
+
 	// GetLoadBalancerStatus returns the struct describing the status of the given load balancer.
 	GetLoadBalancerStatus(lbName string) (*status.LoadBalancerStatus, error)
 	// ListLoadBalancerStatuses returns status of all MCI ingresses (load balancers).
 	ListLoadBalancerStatuses() ([]status.LoadBalancerStatus, error)
+	// RemoveClustersFromStatus removes the given clusters from the LoadBalancerStatus.
+	RemoveClustersFromStatus(clusters []string) error
 }

--- a/app/kubemci/pkg/gcp/instances/fake_instancegetter.go
+++ b/app/kubemci/pkg/gcp/instances/fake_instancegetter.go
@@ -18,12 +18,14 @@ import (
 	compute "google.golang.org/api/compute/v1"
 )
 
-var FakeInstance = &compute.Instance{
-	Name: "fake-instance",
-	Zone: "my-zone",
-	Tags: &compute.Tags{
-		Items: []string{"fake-tag"},
-	},
+func newInstance(igUrl string) *compute.Instance {
+	return &compute.Instance{
+		Name: igUrl,
+		Zone: igUrl,
+		Tags: &compute.Tags{
+			Items: []string{igUrl},
+		},
+	}
 }
 
 func NewFakeInstanceGetter() InstanceGetterInterface {
@@ -38,5 +40,5 @@ type FakeInstanceGetter struct {
 var _ InstanceGetterInterface = &FakeInstanceGetter{}
 
 func (g *FakeInstanceGetter) GetInstance(igUrl string) (*compute.Instance, error) {
-	return FakeInstance, nil
+	return newInstance(igUrl), nil
 }

--- a/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
+++ b/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
@@ -135,7 +135,7 @@ func (l *LoadBalancerSyncer) CreateLoadBalancer(ing *v1beta1.Ingress, forceUpdat
 	if portsErr != nil {
 		err = multierror.Append(err, portsErr)
 	}
-	// Can not really create any backend service without named portsand instance groups. No point continuing.
+	// Can not really create any backend service without named ports and instance groups. No point continuing.
 	if len(igs) == 0 {
 		err = multierror.Append(err, fmt.Errorf("No instance group found. Can not continue"))
 		return err
@@ -217,8 +217,8 @@ func (l *LoadBalancerSyncer) CreateLoadBalancer(ing *v1beta1.Ingress, forceUpdat
 }
 
 // DeleteLoadBalancer deletes the GCP resources associated with the L7 GCP load balancer for the given ingress.
+// TODO(nikhiljindal): Do not require the ingress yaml from users. Just the name should be enough. We can fetch ingress YAML from one of the clusters.
 func (l *LoadBalancerSyncer) DeleteLoadBalancer(ing *v1beta1.Ingress) error {
-	// TODO(nikhiljindal): Dont require the ingress yaml from users. Just the name should be enough. We can fetch ingress YAML from one of the clusters.
 	client, cErr := getAnyClient(l.clients)
 	if cErr != nil {
 		// No point in continuing without a client.
@@ -262,8 +262,8 @@ func (l *LoadBalancerSyncer) DeleteLoadBalancer(ing *v1beta1.Ingress) error {
 }
 
 // DeleteLoadBalancer deletes the GCP resources associated with the L7 GCP load balancer for the given ingress.
+// TODO(nikhiljindal): Do not require the ingress yaml from users. Just the name should be enough. We can fetch ingress YAML from one of the clusters.
 func (l *LoadBalancerSyncer) RemoveFromClusters(ing *v1beta1.Ingress, removeClients map[string]kubeclient.Interface, forceUpdate bool) error {
-	// TODO(nikhiljindal): Dont require the ingress yaml from users. Just the name should be enough. We can fetch ingress YAML from one of the clusters.
 	client, cErr := getAnyClient(l.clients)
 	if cErr != nil {
 		// No point in continuing without a client.
@@ -287,6 +287,8 @@ func (l *LoadBalancerSyncer) RemoveFromClusters(ing *v1beta1.Ingress, removeClie
 		// Aggregate errors and return all at the end.
 		err = multierror.Append(err, fwErr)
 	}
+
+	// Convert the map of instance groups to a flat array.
 	igsForBE := []string{}
 	for k := range removeIGLinks {
 		igsForBE = append(igsForBE, removeIGLinks[k]...)

--- a/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
+++ b/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
@@ -127,10 +127,22 @@ func (l *LoadBalancerSyncer) CreateLoadBalancer(ing *v1beta1.Ingress, forceUpdat
 		fmt.Println(hcErr)
 		err = multierror.Append(err, hcErr)
 	}
-	igs, namedPorts, igErr := l.getIGsAndNamedPorts(ing)
-	// Cant really create any backend service without named ports. No point continuing.
+	igs, igErr := l.getIGs(ing, l.clients)
 	if igErr != nil {
-		return multierror.Append(err, igErr)
+		err = multierror.Append(err, igErr)
+	}
+	namedPorts, portsErr := l.getNamedPorts(igs)
+	if portsErr != nil {
+		err = multierror.Append(err, portsErr)
+	}
+	// Can not really create any backend service without named portsand instance groups. No point continuing.
+	if len(igs) == 0 {
+		err = multierror.Append(err, fmt.Errorf("No instance group found. Can not continue"))
+		return err
+	}
+	if len(namedPorts) == 0 {
+		err = multierror.Append(err, fmt.Errorf("No named ports found. Can not continue"))
+		return err
 	}
 	igsForBE := []string{}
 	for k := range igs {
@@ -249,6 +261,58 @@ func (l *LoadBalancerSyncer) DeleteLoadBalancer(ing *v1beta1.Ingress) error {
 	return err
 }
 
+// DeleteLoadBalancer deletes the GCP resources associated with the L7 GCP load balancer for the given ingress.
+func (l *LoadBalancerSyncer) RemoveFromClusters(ing *v1beta1.Ingress, removeClients map[string]kubeclient.Interface, forceUpdate bool) error {
+	// TODO(nikhiljindal): Dont require the ingress yaml from users. Just the name should be enough. We can fetch ingress YAML from one of the clusters.
+	client, cErr := getAnyClient(l.clients)
+	if cErr != nil {
+		// No point in continuing without a client.
+		return cErr
+	}
+	var err error
+	ports := l.ingToNodePorts(ing, client)
+	removeIGLinks, igErr := l.getIGs(ing, removeClients)
+	if igErr != nil {
+		return multierror.Append(err, igErr)
+	}
+	// Can not really update any resource without igs. No point continuing.
+	// Note: User can run into this if they are trying to remove their already deleted clusters.
+	// TODO: Allow them to proceed to clean up whatever they can by using --force.
+	if len(removeIGLinks) == 0 {
+		err := multierror.Append(err, fmt.Errorf("No instance group found. Can not continue"))
+		return err
+	}
+
+	if fwErr := l.fws.RemoveFromClusters(l.lbName, removeIGLinks); fwErr != nil {
+		// Aggregate errors and return all at the end.
+		err = multierror.Append(err, fwErr)
+	}
+	igsForBE := []string{}
+	for k := range removeIGLinks {
+		igsForBE = append(igsForBE, removeIGLinks[k]...)
+	}
+
+	if beErr := l.bss.RemoveFromClusters(ports, igsForBE); beErr != nil {
+		// Aggregate errors and return all at the end.
+		err = multierror.Append(err, beErr)
+	}
+
+	// Convert the client map to an array of cluster names.
+	removeClusters := make([]string, len(removeClients))
+	removeIndex := 0
+	for k := range removeClients {
+		removeClusters[removeIndex] = k
+		removeIndex++
+	}
+	// Update the forwarding rule status at the end.
+	if frErr := l.frs.RemoveClustersFromStatus(removeClusters); frErr != nil {
+		// Aggregate errors and return all at the end.
+		err = multierror.Append(err, frErr)
+	}
+
+	return err
+}
+
 // PrintStatus prints the current status of the load balancer.
 func (l *LoadBalancerSyncer) PrintStatus() (string, error) {
 	sd, err := l.frs.GetLoadBalancerStatus(l.lbName)
@@ -298,39 +362,42 @@ func (l *LoadBalancerSyncer) getIPAddress(ing *v1beta1.Ingress) (string, error) 
 	return ip.Address, nil
 }
 
-// Returns links to all instance groups and named ports on any one of them.
-// Note that it picks an instance group at random and returns the named ports for that instance group, assuming that the named ports are same on all instance groups.
-// Also note that this returns all named ports on the instance group and not just the ones relevant to the given ingress.
-func (l *LoadBalancerSyncer) getIGsAndNamedPorts(ing *v1beta1.Ingress) (map[string][]string, backendservice.NamedPortsMap, error) {
+// Returns links to all instance groups corresponding the given ingress for the given clients.
+func (l *LoadBalancerSyncer) getIGs(ing *v1beta1.Ingress, clients map[string]kubeclient.Interface) (map[string][]string, error) {
 	var err error
 	igs := make(map[string][]string, len(l.clients))
-	var igFromLastCluster string
 	// Get instance groups from all clusters.
-	for cluster, client := range l.clients {
-		igsFromCluster, getIGsErr := l.getIGs(ing, client, cluster)
+	for cluster, client := range clients {
+		igsFromCluster, getIGsErr := getIGsForCluster(ing, client, cluster)
 		if getIGsErr != nil {
 			err = multierror.Append(err, getIGsErr)
 			continue
 		}
 		igs[cluster] = igsFromCluster
-		igFromLastCluster = igsFromCluster[0]
 	}
-	if len(igs) == 0 {
-		err = multierror.Append(err, fmt.Errorf("Cannot fetch named ports since fetching instance groups failed"))
-		return nil, backendservice.NamedPortsMap{}, err
-	}
-	// Compute named ports for igs from the last cluster.
-	// We can compute it from any instance group, all are expected to have the same named ports.
-	namedPorts, namedPortsErr := l.getNamedPorts(igFromLastCluster)
-	if namedPortsErr != nil {
-		err = multierror.Append(err, namedPortsErr)
-	}
-	return igs, namedPorts, err
+	return igs, err
 }
 
-// Returns the instance groups corresponding to the given ingress.
-// It fetches the given ingress from all clusters and extracts the instance group annotations on them to get the list of instance groups.
-func (l *LoadBalancerSyncer) getIGs(ing *v1beta1.Ingress, client kubeclient.Interface, cluster string) ([]string, error) {
+// Returns named ports on an instance from the given list.
+// Note that it picks an instance group at random and returns the named ports for that instance group, assuming that the named ports are same on all instance groups.
+// Also note that this returns all named ports on the instance group and not just the ones relevant to the given ingress.
+func (l *LoadBalancerSyncer) getNamedPorts(igs map[string][]string) (backendservice.NamedPortsMap, error) {
+	if len(igs) == 0 {
+		return backendservice.NamedPortsMap{}, fmt.Errorf("Cannot fetch named ports since instance groups list is empty")
+	}
+
+	// Pick an IG at random.
+	var ig string
+	for _, v := range igs {
+		ig = v[0]
+		break
+	}
+	return l.getNamedPortsForIG(ig)
+}
+
+// Returns the instance groups corresponding to the given cluster.
+// It fetches the given ingress from the cluster and extracts the instance group annotations on it to get the list of instance groups.
+func getIGsForCluster(ing *v1beta1.Ingress, client kubeclient.Interface, cluster string) ([]string, error) {
 	fmt.Println("Determining instance groups for cluster", cluster)
 	key := annotations.InstanceGroupsAnnotationKey
 	// Keep trying until ingress gets the instance group annotation.
@@ -373,7 +440,7 @@ func (l *LoadBalancerSyncer) getIGs(ing *v1beta1.Ingress, client kubeclient.Inte
 	return nil, nil
 }
 
-func (l *LoadBalancerSyncer) getNamedPorts(igUrl string) (backendservice.NamedPortsMap, error) {
+func (l *LoadBalancerSyncer) getNamedPortsForIG(igUrl string) (backendservice.NamedPortsMap, error) {
 	zone, name, err := utils.GetZoneAndNameFromIGUrl(igUrl)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
As per https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/58, adding a new `kubemci remove-clusters` command that users can use to remove an existing MCI from some clusters.

Things left to be done:
* This still causes downtime. Filed https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/145 for that.
* This doesnt use --force yet.
* Adding more tests.

This PR has already become too big, so will do those in follow up PRs.

cc @csbell @G-Harmon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/146)
<!-- Reviewable:end -->
