### PR TITLE
Basic --validate flag: Checks that NodePort is the same in each cluster.

### DIFF
--- a/app/kubemci/cmd/create.go
+++ b/app/kubemci/cmd/create.go
@@ -56,6 +56,8 @@ type CreateOptions struct {
 	// the resource does not exist, or is already the correct
 	// value, then 'force' is a no-op.
 	ForceUpdate bool
+	// Validation of Ingress spec and Kubernetes Services setup.
+	Validate bool
 	// Name of the namespace for the ingress when none is provided (mismatch of option with spec causes an error).
 	// Optional.
 	Namespace string
@@ -66,6 +68,8 @@ type CreateOptions struct {
 
 func NewCmdCreate(out, err io.Writer) *cobra.Command {
 	var options CreateOptions
+	// Enable validation by default.
+	options.Validate = true
 
 	cmd := &cobra.Command{
 		Use:   "create [lbname]",
@@ -95,6 +99,7 @@ func addCreateFlags(cmd *cobra.Command, options *CreateOptions) error {
 	// TODO(nikhiljindal): Add a short flag "-p" if it seems useful.
 	cmd.Flags().StringVarP(&options.GCPProject, "gcp-project", "", options.GCPProject, "[optional] name of the gcp project. Is fetched using gcloud config get-value project if unset here")
 	cmd.Flags().BoolVarP(&options.ForceUpdate, "force", "f", options.ForceUpdate, "[optional] overwrite existing settings if they are different")
+	cmd.Flags().BoolVarP(&options.Validate, "validate", "", options.Validate, "[optional] If enabled (default), do some validation checks and potentially return an error, before creating load balancer")
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", options.Namespace, "[optional] namespace for the ingress only if left unspecified by ingress spec")
 	cmd.Flags().StringVarP(&options.StaticIPName, "static-ip", "", options.StaticIPName, "[optional] Global Static IP name to use only if left unspecified by ingress spec")
 	return nil
@@ -154,5 +159,5 @@ func runCreate(options *CreateOptions, args []string) error {
 	if err != nil {
 		return err
 	}
-	return lbs.CreateLoadBalancer(&ing, options.ForceUpdate, clusters)
+	return lbs.CreateLoadBalancer(&ing, options.ForceUpdate, options.Validate, clusters)
 }

--- a/app/kubemci/pkg/gcp/healthcheck/healthchecksyncer.go
+++ b/app/kubemci/pkg/gcp/healthcheck/healthchecksyncer.go
@@ -169,7 +169,7 @@ func getJsonIgnoreErr(v interface{}) string {
 }
 
 func (h *HealthCheckSyncer) ensureHealthCheck(lbName string, port ingressbe.ServicePort, path string, forceUpdate bool) (*compute.HealthCheck, error) {
-	fmt.Println("Ensuring health check for port:", port)
+	fmt.Printf("Ensuring health check for port: %+v\n", port)
 	desiredHC, err := h.desiredHealthCheck(lbName, port, path)
 	if err != nil {
 		return nil, fmt.Errorf("error %s in computing desired health check", err)

--- a/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
+++ b/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
@@ -24,11 +24,8 @@ import (
 
 	"github.com/golang/glog"
 	multierror "github.com/hashicorp/go-multierror"
-	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/ingress-gce/pkg/annotations"
 	ingressbe "k8s.io/ingress-gce/pkg/backends"
@@ -49,6 +46,8 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/targetproxy"
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/urlmap"
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/utils"
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/kubeutils"
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/validations"
 )
 
 const (
@@ -108,12 +107,22 @@ func NewLoadBalancerSyncer(lbName string, clients map[string]kubeclient.Interfac
 
 // CreateLoadBalancer creates the GCP resources necessary for an L7 GCP load balancer corresponding to the given ingress.
 // clusters is the list of clusters that this load balancer is spread to.
-func (l *LoadBalancerSyncer) CreateLoadBalancer(ing *v1beta1.Ingress, forceUpdate bool, clusters []string) error {
+func (l *LoadBalancerSyncer) CreateLoadBalancer(ing *v1beta1.Ingress, forceUpdate, validate bool, clusters []string) error {
 	client, cErr := getAnyClient(l.clients)
 	if cErr != nil {
 		// No point in continuing without a client.
 		return cErr
 	}
+
+	if validate {
+		if err := validations.Validate(l.clients, ing); err != nil {
+			return fmt.Errorf("validation failed: %s", err)
+		}
+		glog.Infof("Validation passed.")
+	} else {
+		fmt.Println("Validation skipped. (Set --validate to enable.)")
+	}
+
 	ports := l.ingToNodePorts(ing, client)
 	ipAddr, err := l.getIPAddress(ing)
 	if err != nil {
@@ -510,7 +519,7 @@ func (l *LoadBalancerSyncer) getNamedPortsForIG(igUrl string) (backendservice.Na
 	fmt.Printf("Fetched instance group: %s/%s, got named ports: ", zone, name)
 	namedPorts := backendservice.NamedPortsMap{}
 	for _, np := range ig.NamedPorts {
-		fmt.Printf("port: %v ", np)
+		fmt.Printf("port: %+v ", np)
 		namedPorts[np.Port] = np
 	}
 	fmt.Printf("\n")
@@ -520,76 +529,28 @@ func (l *LoadBalancerSyncer) ingToNodePorts(ing *v1beta1.Ingress, client kubecli
 	var knownPorts []ingressbe.ServicePort
 	defaultBackend := ing.Spec.Backend
 	if defaultBackend != nil {
-		port, err := l.getServiceNodePort(*defaultBackend, ing.Namespace, client)
+		port, err := kubeutils.GetServiceNodePort(*defaultBackend, ing.Namespace, client)
 		if err != nil {
-			glog.Errorf("%v", err)
+			fmt.Println("error getting service nodeport:", err, ". Ignoring.")
 		} else {
 			knownPorts = append(knownPorts, port)
 		}
 	}
 	for _, rule := range ing.Spec.Rules {
 		if rule.HTTP == nil {
-			glog.Errorf("ignoring non http Ingress rule")
+			glog.Warningf("ignoring non http Ingress rule: %v", rule)
 			continue
 		}
 		for _, path := range rule.HTTP.Paths {
-			port, err := l.getServiceNodePort(path.Backend, ing.Namespace, client)
+			port, err := kubeutils.GetServiceNodePort(path.Backend, ing.Namespace, client)
 			if err != nil {
-				glog.Errorf("%v", err)
+				fmt.Println("error getting service nodeport:", err, ". Ignoring.")
 				continue
 			}
 			knownPorts = append(knownPorts, port)
 		}
 	}
 	return knownPorts
-}
-
-func (l *LoadBalancerSyncer) getServiceNodePort(be v1beta1.IngressBackend, namespace string, client kubeclient.Interface) (ingressbe.ServicePort, error) {
-	svc, err := getSvc(be.ServiceName, namespace, client)
-	// Refactor this code to get serviceport from a given service and share it with kubernetes/ingress.
-	appProtocols, err := annotations.FromService(svc).ApplicationProtocols()
-	if err != nil {
-		return ingressbe.ServicePort{}, err
-	}
-
-	var port *v1.ServicePort
-PortLoop:
-	for _, p := range svc.Spec.Ports {
-		np := p
-		switch be.ServicePort.Type {
-		case intstr.Int:
-			if p.Port == be.ServicePort.IntVal {
-				port = &np
-				break PortLoop
-			}
-		default:
-			if p.Name == be.ServicePort.StrVal {
-				port = &np
-				break PortLoop
-			}
-		}
-	}
-
-	if port == nil {
-		return ingressbe.ServicePort{}, fmt.Errorf("could not find matching nodeport for backend %+v and service %s/%s. Looking for port %+v in %v", be, namespace, be.ServiceName, be.ServicePort, svc.Spec.Ports)
-	}
-
-	proto := annotations.ProtocolHTTP
-	if protoStr, exists := appProtocols[port.Name]; exists {
-		proto = annotations.AppProtocol(protoStr)
-	}
-
-	p := ingressbe.ServicePort{
-		NodePort: int64(port.NodePort),
-		Protocol: proto,
-		SvcName:  types.NamespacedName{Namespace: namespace, Name: be.ServiceName},
-		SvcPort:  be.ServicePort,
-	}
-	return p, nil
-}
-
-func getSvc(svcName, nsName string, client kubeclient.Interface) (*v1.Service, error) {
-	return client.CoreV1().Services(nsName).Get(svcName, metav1.GetOptions{})
 }
 
 func getIng(ingName, nsName string, client kubeclient.Interface) (*v1beta1.Ingress, error) {
@@ -604,6 +565,7 @@ func getAnyClient(clients map[string]kubeclient.Interface) (kubeclient.Interface
 	}
 	// Return the client for any cluster.
 	for k := range clients {
+		glog.V(2).Infof("getAnyClient: using client for cluster %s", k)
 		return clients[k], nil
 	}
 	return nil, nil

--- a/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer_test.go
+++ b/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer_test.go
@@ -17,6 +17,7 @@ package loadbalancer
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"reflect"
 	"testing"
 
@@ -41,6 +42,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/status"
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/targetproxy"
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/urlmap"
+	"github.com/golang/glog"
 )
 
 func newLoadBalancerSyncer(lbName string) *LoadBalancerSyncer {
@@ -78,11 +80,11 @@ func TestCreateLoadBalancer(t *testing.T) {
 	}
 	// Reserve a global address. User is supposed to do this before calling CreateLoadBalancer.
 	lbc.ipp.ReserveGlobalAddress(ipAddress)
-	ing, err := setupLBCForCreateIng(lbc, nodePort, igName, igZone, zoneLink, ipAddress)
+	ing, err := setupLBCForCreateIng(lbc, nodePort, false /*randNodePort*/, igName, igZone, zoneLink, ipAddress)
 	if err != nil {
 		t.Fatalf("unexpected error in test setup: %s", err)
 	}
-	if err := lbc.CreateLoadBalancer(ing, true /*forceUpdate*/, clusters); err != nil {
+	if err := lbc.CreateLoadBalancer(ing, true /*forceUpdate*/, true /*validate*/, clusters); err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}
 	// Verify client actions.
@@ -90,34 +92,38 @@ func TestCreateLoadBalancer(t *testing.T) {
 	for k, v := range lbc.clients {
 		client := v.(*fake.Clientset)
 		actions := client.Actions()
-		if len(actions) == 1 {
-			// The action should have been to fetch the ingress.
-			getIngName := actions[0].(core.GetAction).GetName()
-			if getIngName != ing.Name {
-				t.Errorf("unexpected get for %s, expected: %s", getIngName, ing.Name)
-			}
-		} else if len(actions) == 2 {
-			// First action should have been to fetch the service and second one should have been to fetch the ingress.
-			fetchedSvc = true
-			getSvcName := actions[0].(core.GetAction).GetName()
-			if getSvcName != "my-svc" {
-				t.Errorf("unexpected get for %s, expected: my-svc", getSvcName)
-			}
-			getIngName := actions[1].(core.GetAction).GetName()
-			if getIngName != ing.Name {
-				t.Errorf("unexpected get for %s, expected: %s", getIngName, ing.Name)
-			}
+		// Validation (same for each cluster):
+		//   1x GET-Service for path=/foo.
+		//   1x GET-Service for default backend.
+		// Start of setup (using a random cluster's client):
+		//   1x GET-Service for default backend.
+		//   1x GET-Service for path=/foo.
+		// The last action should always be GET-Ingress, once for each cluster.
+		// This is how we get 3 actions for 1 cluster and 5 actions for the other.
+		fetchedSvc = fetchedSvc || len(actions) == 5
+		if !(len(actions) == 3 || len(actions) == 5) {
+			t.Errorf("Bad number of actions for cluster '%s'. Expected 3 or 5. Got %d: %v", k, len(actions), actions)
 		} else {
-			t.Errorf("unexpected number of actions for client for cluster %s: %v", k, actions)
+			for i := 0; i < len(actions)-1; i++ {
+				getSvcName := actions[i].(core.GetAction).GetName()
+				if getSvcName != "my-svc" {
+					t.Errorf("unexpected get for %s, expected: my-svc", getSvcName)
+				}
+			}
+			getIngName := actions[len(actions)-1].(core.GetAction).GetName()
+			if getIngName != ing.Name {
+				t.Errorf("unexpected get for %s, expected: %s", getIngName, ing.Name)
+			}
 		}
 	}
 	if !fetchedSvc {
-		t.Errorf("None of the client was used to fetch the service")
+		t.Errorf("None of the clients were used to fetch the service")
 	}
 	// Verify that the expected healthcheck was created.
 	fhc := lbc.hcs.(*healthcheck.FakeHealthCheckSyncer)
-	if len(fhc.EnsuredHealthChecks) != 1 {
-		t.Fatalf("unexpected number of health checks. expected: %d, got: %d", 1, len(fhc.EnsuredHealthChecks))
+	if len(fhc.EnsuredHealthChecks) != 2 {
+		t.Errorf("unexpected number of health checks. expected: 2, got: %d: %+v", len(fhc.EnsuredHealthChecks),
+			fhc.EnsuredHealthChecks)
 	}
 	hc := fhc.EnsuredHealthChecks[0]
 	if hc.LBName != lbName || hc.Port.NodePort != nodePort {
@@ -125,8 +131,8 @@ func TestCreateLoadBalancer(t *testing.T) {
 	}
 	// Verify that the expected backend service was created.
 	fbs := lbc.bss.(*backendservice.FakeBackendServiceSyncer)
-	if len(fbs.EnsuredBackendServices) != 1 {
-		t.Fatalf("unexpected number of backend services. expected: %d, got: %d", 1, len(fbs.EnsuredBackendServices))
+	if len(fbs.EnsuredBackendServices) != 2 {
+		t.Errorf("unexpected number of backend services. expected: 2, got: %d", len(fbs.EnsuredBackendServices))
 	}
 	bs := fbs.EnsuredBackendServices[0]
 	if bs.LBName != lbName {
@@ -193,7 +199,66 @@ func TestCreateLoadBalancer(t *testing.T) {
 	}
 }
 
-func setupLBCForCreateIng(lbc *LoadBalancerSyncer, nodePort int64, igName, igZone, zoneLink string, ipAddress *compute.Address) (*v1beta1.Ingress, error) {
+func TestCreateLoadBalancerBadNodePortsValidate(t *testing.T) {
+	lbName := "lb-name"
+	igName := "my-fake-ig"
+	igZone := "my-fake-zone"
+	zoneLink := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/fake-project/zones/%s", igZone)
+	clusters := []string{"cluster1", "cluster2"}
+	lbc := newLoadBalancerSyncer(lbName)
+	ipAddress := &compute.Address{
+		Name:    "ipAddressName",
+		Address: "1.2.3.4",
+	}
+	// Reserve a global address. User is supposed to do this before calling CreateLoadBalancer.
+	lbc.ipp.ReserveGlobalAddress(ipAddress)
+	ing, err := setupLBCForCreateIng(lbc, -1 /*nodePort*/, true /*randNodePort*/, igName, igZone, zoneLink, ipAddress)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	if err := lbc.CreateLoadBalancer(ing, true /*forceUpdate*/, true /*validate*/, clusters); err == nil {
+		t.Errorf("want: a validation error while creating load balancer: got: nil")
+	}
+	// Verify client actions.
+	for k, v := range lbc.clients {
+		client := v.(*fake.Clientset)
+		actions := client.Actions()
+		if len(actions) != 2 {
+			t.Errorf("Bad number of actions for cluster '%s'. Expected 1. Got %d: %+v", k, len(actions), actions)
+		} else {
+			for _, action := range actions {
+				getSvcName := action.(core.GetAction).GetName()
+				if getSvcName != "my-svc" {
+					t.Errorf("unexpected GET for '%s', expected: my-svc", getSvcName)
+				}
+			}
+		}
+	}
+}
+
+func TestCreateLoadBalancerBadNodePortsNoValidate(t *testing.T) {
+	lbName := "lb-name"
+	igName := "my-fake-ig"
+	igZone := "my-fake-zone"
+	zoneLink := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/fake-project/zones/%s", igZone)
+	clusters := []string{"cluster1", "cluster2"}
+	lbc := newLoadBalancerSyncer(lbName)
+	ipAddress := &compute.Address{
+		Name:    "ipAddressName",
+		Address: "1.2.3.4",
+	}
+	// Reserve a global address. User is supposed to do this before calling CreateLoadBalancer.
+	lbc.ipp.ReserveGlobalAddress(ipAddress)
+	ing, err := setupLBCForCreateIng(lbc, -1 /*nodePort*/, true /*randNodePort*/, igName, igZone, zoneLink, ipAddress)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	if err := lbc.CreateLoadBalancer(ing, true /*forceUpdate*/, false /*validate*/, clusters); err != nil {
+		t.Errorf("expected no error Creating Load Balancer. Got: %s", err)
+	}
+}
+
+func setupLBCForCreateIng(lbc *LoadBalancerSyncer, nodePort int64, randNodePort bool, igName, igZone, zoneLink string, ipAddress *compute.Address) (*v1beta1.Ingress, error) {
 	portName := "my-port-name"
 	// Create ingress with instance groups annotation.
 	annotationsValue := []struct {
@@ -236,12 +301,21 @@ func setupLBCForCreateIng(lbc *LoadBalancerSyncer, nodePort int64, igName, igZon
 					},
 				},
 			},
+			Backend: &v1beta1.IngressBackend{
+				ServiceName: "my-svc",
+				ServicePort: intstr.FromInt(80),
+			},
 		},
 	}
+
 	for _, c := range lbc.clients {
 		client := c.(*fake.Clientset)
 		// Add a reaction to return a fake service.
 		client.AddReactor("get", "services", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+			if randNodePort {
+				nodePort = int64(rand.Int31n(1000) + 30000)
+				glog.Infof("Using a randomized NodePort: %d", nodePort)
+			}
 			ret = &v1.Service{
 				Spec: v1.ServiceSpec{
 					Ports: []v1.ServicePort{
@@ -289,11 +363,11 @@ func TestDeleteLoadBalancer(t *testing.T) {
 	}
 	// Reserve a global address. User is supposed to do this before calling CreateLoadBalancer.
 	lbc.ipp.ReserveGlobalAddress(ipAddress)
-	ing, err := setupLBCForCreateIng(lbc, nodePort, igName, igZone, zoneLink, ipAddress)
+	ing, err := setupLBCForCreateIng(lbc, nodePort, false /*randNodePort*/, igName, igZone, zoneLink, ipAddress)
 	if err != nil {
 		t.Fatalf("unexpected error in test setup: %s", err)
 	}
-	if err := lbc.CreateLoadBalancer(ing, true /*forceUpdate*/, clusters); err != nil {
+	if err := lbc.CreateLoadBalancer(ing, true /*forceUpdate*/, true /*validate*/, clusters); err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}
 	fhc := lbc.hcs.(*healthcheck.FakeHealthCheckSyncer)
@@ -358,11 +432,11 @@ func TestRemoveFromClusters(t *testing.T) {
 	}
 	// Reserve a global address. User is supposed to do this before calling CreateLoadBalancer.
 	lbc.ipp.ReserveGlobalAddress(ipAddress)
-	ing, err := setupLBCForCreateIng(lbc, nodePort, igName, igZone, zoneLink, ipAddress)
+	ing, err := setupLBCForCreateIng(lbc, nodePort, false /*randNodePort*/, igName, igZone, zoneLink, ipAddress)
 	if err != nil {
 		t.Fatalf("unexpected error in test setup: %s", err)
 	}
-	if err := lbc.CreateLoadBalancer(ing, true /*forceUpdate*/, clusters); err != nil {
+	if err := lbc.CreateLoadBalancer(ing, true /*forceUpdate*/, true /*validate*/, clusters); err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}
 	fhc := lbc.hcs.(*healthcheck.FakeHealthCheckSyncer)
@@ -431,7 +505,7 @@ func TestRemoveClustersFromStatus(t *testing.T) {
 	}
 	// Reserve a global address. User is supposed to do this before calling CreateLoadBalancer.
 	lbc.ipp.ReserveGlobalAddress(ipAddress)
-	ing, err := setupLBCForCreateIng(lbc, nodePort, igName, igZone, zoneLink, ipAddress)
+	ing, err := setupLBCForCreateIng(lbc, nodePort, false /*randNodePort*/, igName, igZone, zoneLink, ipAddress)
 	if err != nil {
 		t.Fatalf("unexpected error in test setup: %s", err)
 	}
@@ -463,7 +537,7 @@ func TestRemoveClustersFromStatus(t *testing.T) {
 		},
 	}
 	for _, c := range testCases {
-		if err := lbc.CreateLoadBalancer(ing, false /*forceUpdate*/, clusters); err != nil {
+		if err := lbc.CreateLoadBalancer(ing, false /*forceUpdate*/, true /*validate*/, clusters); err != nil {
 			t.Fatalf("unexpected error %s", err)
 		}
 		if c.frHasStatus {

--- a/app/kubemci/pkg/gcp/urlmap/urlmapsyncer.go
+++ b/app/kubemci/pkg/gcp/urlmap/urlmapsyncer.go
@@ -363,8 +363,8 @@ func (s *URLMapSyncer) ingToURLMap(ing *v1beta1.Ingress, beMap backendservice.Ba
 	var defaultBackend *compute.BackendService
 	if ing.Spec.Backend == nil {
 		// TODO(nikhiljindal): Be able to create a default backend service.
-		// For now, we require users to specify it and generate an error if its nil.
-		// We cant create a url map without a default service, so no point continuing.
+		// For now, we require users to specify it and generate an error if it's nil.
+		// We can't create a url map without a default service, so no point continuing.
 		err = multierror.Append(err, fmt.Errorf("unexpected: ing.spec.backend is nil. Multicluster ingress needs a user specified default backend"))
 		return nil, err
 	}

--- a/app/kubemci/pkg/kubeutils/utils.go
+++ b/app/kubemci/pkg/kubeutils/utils.go
@@ -22,13 +22,17 @@ import (
 
 	"github.com/golang/glog"
 	multierror "github.com/hashicorp/go-multierror"
+	"k8s.io/api/core/v1"
 	api_v1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/ingress-gce/pkg/annotations"
 	ingressbe "k8s.io/ingress-gce/pkg/backends"
 )
 
@@ -216,4 +220,56 @@ func ObjectMetaAndSpecEquivalent(a, b runtime.Object, ignoreAnnotationKeys map[s
 	specA := reflect.ValueOf(a).Elem().FieldByName("Spec").Interface()
 	specB := reflect.ValueOf(b).Elem().FieldByName("Spec").Interface()
 	return ObjectMetaEquivalent(objectMetaA, objectMetaB, ignoreAnnotationKeys) && reflect.DeepEqual(specA, specB)
+}
+
+// GetServiceNodePort takes an IngressBackend and returns a corresponding ServicePort
+func GetServiceNodePort(be v1beta1.IngressBackend, namespace string, client kubeclient.Interface) (ingressbe.ServicePort, error) {
+	svc, err := getSvc(be.ServiceName, namespace, client)
+	// Refactor this code to get serviceport from a given service and share it with kubernetes/ingress.
+	appProtocols, err := annotations.FromService(svc).ApplicationProtocols()
+	if err != nil {
+		return ingressbe.ServicePort{}, err
+	}
+
+	var port *v1.ServicePort
+PortLoop:
+	for _, p := range svc.Spec.Ports {
+		np := p
+		switch be.ServicePort.Type {
+		case intstr.Int:
+			if p.Port == be.ServicePort.IntVal {
+				port = &np
+				break PortLoop
+			}
+		default:
+			if p.Name == be.ServicePort.StrVal {
+				port = &np
+				break PortLoop
+			}
+		}
+	}
+
+	if port == nil {
+		return ingressbe.ServicePort{}, fmt.Errorf("could not find matching nodeport for backend %+v and service %s/%s. Looking for port %+v in %v", be, namespace, be.ServiceName, be.ServicePort, svc.Spec.Ports)
+	}
+
+	proto := annotations.ProtocolHTTP
+	if protoStr, exists := appProtocols[port.Name]; exists {
+		glog.V(2).Infof("service %s/%s, port %q: using protocol to %q", namespace, be.ServiceName, port, protoStr)
+		proto = annotations.AppProtocol(protoStr)
+	}
+
+	p := ingressbe.ServicePort{
+		NodePort: int64(port.NodePort),
+		Protocol: proto,
+		SvcName:  types.NamespacedName{Namespace: namespace, Name: be.ServiceName},
+		SvcPort:  be.ServicePort,
+	}
+	glog.Infof("Found ServicePort: %+v", p)
+	return p, nil
+
+}
+
+func getSvc(svcName, nsName string, client kubeclient.Interface) (*v1.Service, error) {
+	return client.CoreV1().Services(nsName).Get(svcName, meta_v1.GetOptions{})
 }

--- a/app/kubemci/pkg/validations/validations.go
+++ b/app/kubemci/pkg/validations/validations.go
@@ -1,0 +1,91 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"fmt"
+
+	kubeclient "k8s.io/client-go/kubernetes"
+
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/kubeutils"
+	"github.com/golang/glog"
+	multierror "github.com/hashicorp/go-multierror"
+	"k8s.io/api/extensions/v1beta1"
+)
+
+func Validate(clients map[string]kubeclient.Interface, ing *v1beta1.Ingress) error {
+	return servicesNodePortsSame(clients, ing)
+}
+
+// servicesNodePortsSame checks that for each backend/service, the services are
+// all listening on the same node port in all clusters.
+func servicesNodePortsSame(clients map[string]kubeclient.Interface, ing *v1beta1.Ingress) error {
+	var multiErr error
+	for _, rule := range ing.Spec.Rules {
+		if rule.HTTP == nil {
+			glog.Warningf("ignoring non http Ingress rule: %v", rule)
+			continue
+		}
+		for _, path := range rule.HTTP.Paths {
+			glog.V(3).Infof("Validating path: %s", path.Path)
+			if err := nodePortSameInAllClusters(path.Backend, ing.Namespace, clients); err != nil {
+				multierror.Append(multiErr, fmt.Errorf("nodePort validation error for service '%s/%s': %s", ing.Namespace, path.Backend.ServiceName, err))
+			} else {
+				glog.V(1).Infof("path: %s: passed validation", path.Path)
+			}
+		}
+	}
+	glog.V(2).Infof("Checking default backend's nodeports.")
+
+	if ing.Spec.Backend != nil {
+		if err := nodePortSameInAllClusters(*ing.Spec.Backend, ing.Namespace, clients); err != nil {
+			multiErr = multierror.Append(multiErr,
+				fmt.Errorf("nodePort validation error for default backend service '%s/%s': %s", *ing.Spec.Backend, ing.Namespace, err))
+		}
+		glog.V(1).Infof("Default backend's nodeports passed validation.")
+	} else {
+		multiErr = multierror.Append(multiErr, fmt.Errorf("unexpected: ing.spec.backend is nil. Multicluster ingress needs a user-specified default backend"))
+	}
+	return multiErr
+}
+
+// nodePortSameInAllClusters checks that the given backend's service is running
+// on the same NodePort in all clusters (defined by clients).
+func nodePortSameInAllClusters(backend v1beta1.IngressBackend, namespace string, clients map[string]kubeclient.Interface) error {
+	nodePort := int64(-1)
+	var firstClusterName string
+	// TODO(G-Harmon): We could provide the list of all clusters that are mismatching instead of just 1.
+	for clientName, client := range clients {
+		glog.V(2).Infof("Checking cluster: %s", clientName)
+
+		servicePort, err := kubeutils.GetServiceNodePort(backend, namespace, client)
+		if err != nil {
+			return fmt.Errorf("Could not get service NodePort in cluster %s: %s", clientName, err)
+		}
+		glog.V(2).Infof("cluster %s: Service's servicePort: %+v", clientName, servicePort)
+		clusterNodePort := servicePort.NodePort
+
+		if nodePort == -1 {
+			nodePort = clusterNodePort
+			firstClusterName = clientName
+			continue
+		}
+		if clusterNodePort != nodePort {
+			return fmt.Errorf("some instances of the '%s/%s' Service (e.g. in '%s') are on NodePort %v, but '%s' is on %v. All clusters must use same NodePort",
+				namespace, backend.ServiceName, firstClusterName, nodePort, clientName, clusterNodePort)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
For every Backend/Service in the Ingress, validates that each cluster
is using the same port number for its NodePort.

This covers some of the work needed for #53.

cc @nikhiljindal @csbell @bowei

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/148)
<!-- Reviewable:end -->
