### PR TITLE
Store LoadBalancerStatus on urlmap instead of storing it on the forwarding rule

### DIFF
--- a/app/kubemci/pkg/gcp/forwardingrule/interfaces.go
+++ b/app/kubemci/pkg/gcp/forwardingrule/interfaces.go
@@ -21,20 +21,19 @@ import (
 // ForwardingRuleSyncerInterface is an interface to manage GCP forwarding rules.
 type ForwardingRuleSyncerInterface interface {
 	// EnsureHttpForwardingRule ensures that the required http forwarding rule exists.
-	// clusters is the list of clusters across which the load balancer is spread.
 	// Will only change an existing rule if forceUpdate = True.
-	EnsureHttpForwardingRule(lbName, ipAddress, targetProxyLink string, clusters []string, forceUpdate bool) error
+	EnsureHttpForwardingRule(lbName, ipAddress, targetProxyLink string, forceUpdate bool) error
 	// EnsureHttpsForwardingRule ensures that the required https forwarding rule exists.
-	// clusters is the list of clusters across which the load balancer is spread.
 	// Will only change an existing rule if forceUpdate = True.
-	EnsureHttpsForwardingRule(lbName, ipAddress, targetProxyLink string, clusters []string, forceUpdate bool) error
+	EnsureHttpsForwardingRule(lbName, ipAddress, targetProxyLink string, forceUpdate bool) error
 	// DeleteForwardingRules deletes the forwarding rules that
 	// EnsureHttpForwardingRule and EnsureHttpsForwardingRule would have created.
 	DeleteForwardingRules() error
 
-	// GetLoadBalancerStatus returns the struct describing the status of the given load balancer.
+	// GetLoadBalancerStatus returns the status of the given load balancer if it is stored on the forwarding rule.
+	// Returns an error with http.StatusNotFound if forwarding rule does not exist.
 	GetLoadBalancerStatus(lbName string) (*status.LoadBalancerStatus, error)
-	// ListLoadBalancerStatuses returns status of all MCI ingresses (load balancers).
+	// ListLoadBalancerStatuses returns status of all MCI ingresses (load balancers) that have statuses stored on forwarding rules.
 	ListLoadBalancerStatuses() ([]status.LoadBalancerStatus, error)
 	// RemoveClustersFromStatus removes the given clusters from the LoadBalancerStatus.
 	RemoveClustersFromStatus(clusters []string) error

--- a/app/kubemci/pkg/gcp/urlmap/interfaces.go
+++ b/app/kubemci/pkg/gcp/urlmap/interfaces.go
@@ -18,15 +18,23 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/backendservice"
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/status"
 )
 
 // URLMapSyncerInterface is an interface to manage GCP url maps.
 type URLMapSyncerInterface interface {
 	// EnsureURLMap ensures that the required url map exists for the given ingress.
-	// Uses beMap to extract the backend services to link to in the url map. Will
-	// only change an existing URL map if forceUpdate=True.
+	// Uses beMap to extract the backend services to link to in the url map.
+	// clusters is the list of clusters across which the load balancer is spread.
+	// Will only change an existing URL map if forceUpdate=True.
 	// Returns the self link for the ensured url map.
-	EnsureURLMap(lbName string, ing *v1beta1.Ingress, beMap backendservice.BackendServicesMap, forceUpdate bool) (string, error)
+	EnsureURLMap(lbName, ipAddress string, clusters []string, ing *v1beta1.Ingress, beMap backendservice.BackendServicesMap, forceUpdate bool) (string, error)
 	// DeleteURLMap deletes the url map that EnsureURLMap would have created.
 	DeleteURLMap() error
+
+	// GetLoadBalancerStatus returns the status of the given load balancer if it is stored on the url map.
+	// Returns an error with http.StatusNotFound if url map does not exist.
+	GetLoadBalancerStatus(lbName string) (*status.LoadBalancerStatus, error)
+	// ListLoadBalancerStatuses returns status of all MCI ingresses (load balancers) that have statuses stored on url maps.
+	ListLoadBalancerStatuses() ([]status.LoadBalancerStatus, error)
 }

--- a/app/kubemci/pkg/goutils/utils.go
+++ b/app/kubemci/pkg/goutils/utils.go
@@ -1,0 +1,24 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package goutils
+
+// MapFromSlice converts a slice of strings to a map.
+func MapFromSlice(strs []string) map[string]struct{} {
+	mymap := make(map[string]struct{})
+	for _, s := range strs {
+		mymap[s] = struct{}{}
+	}
+	return mymap
+}


### PR DESCRIPTION
Ref https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/145

Main changes:
* Stop storing LoadBalancerStatus on forwarding rules
* Start storing status on urlmaps
* Update List and GetStatus to read status from both forwarding rule and urlmap
* Update tests to test that both forwarding rule and urlmaps work fine with and without status.

We wont need special migration for existing MCI's.
Gradually as users update their MCI, status will be migrated from forwarding rule to urlmap.

User visible change:
If they run `kubemci create` again with existing ingress spec, they will expect it to not make any change.
With this, it will throw an error saying user needs to run the command with `--force` to update the forwarding rule and urlmap.
Will include it in release notes.

cc @csbell @G-Harmon 