### PR TITLE
Update remove-clusters to remove clusters from urlmaps status as well

### DIFF
--- a/app/kubemci/pkg/gcp/forwardingrule/fake_forwardingrulesyncer.go
+++ b/app/kubemci/pkg/gcp/forwardingrule/fake_forwardingrulesyncer.go
@@ -114,3 +114,11 @@ func (f *FakeForwardingRuleSyncer) AddStatus(lbName string, status *status.LoadB
 		}
 	}
 }
+
+func (f *FakeForwardingRuleSyncer) RemoveStatus(lbName string) {
+	for i, fr := range f.EnsuredForwardingRules {
+		if fr.LBName == lbName {
+			f.EnsuredForwardingRules[i].Status = nil
+		}
+	}
+}

--- a/app/kubemci/pkg/gcp/forwardingrule/forwardingrulesyncer_test.go
+++ b/app/kubemci/pkg/gcp/forwardingrule/forwardingrulesyncer_test.go
@@ -642,8 +642,9 @@ func TestRemoveClustersFromStatus(t *testing.T) {
 			t.Errorf("%s", err)
 		}
 		// Update status to remove one cluster.
-		if err := frs.RemoveClustersFromStatus([]string{"cluster1"}); err != nil {
-			t.Errorf("unexpected error in updating status to remove clusters: %s", err)
+		err := frs.RemoveClustersFromStatus([]string{"cluster1"})
+		if c.shouldErr != (err != nil) {
+			t.Errorf("unexpected error in updating status to remove clusters, expected err != nil: %v, actual err != nil: %v, err: %s", c.shouldErr, err != nil, err)
 		}
 		// Verify that status description has only one cluster now.
 		if err := verifyClusters(lbName, frs, c.shouldErr, []string{"cluster2"}); err != nil {

--- a/app/kubemci/pkg/gcp/urlmap/fake_urlmapsyncer.go
+++ b/app/kubemci/pkg/gcp/urlmap/fake_urlmapsyncer.go
@@ -33,6 +33,7 @@ type FakeURLMap struct {
 	Clusters  []string
 	Ingress   *v1beta1.Ingress
 	BeMap     backendservice.BackendServicesMap
+	HasStatus bool
 }
 
 type FakeURLMapSyncer struct {
@@ -55,6 +56,7 @@ func (f *FakeURLMapSyncer) EnsureURLMap(lbName, ipAddress string, clusters []str
 		Clusters:  clusters,
 		Ingress:   ing,
 		BeMap:     beMap,
+		HasStatus: false,
 	})
 	return FakeUrlSelfLink, nil
 }
@@ -88,4 +90,25 @@ func (f *FakeURLMapSyncer) ListLoadBalancerStatuses() ([]status.LoadBalancerStat
 		ret = append(ret, status)
 	}
 	return ret, nil
+}
+
+func (f *FakeURLMapSyncer) RemoveClustersFromStatus(clusters []string) error {
+	// TODO(nikhiljindal): Update this once https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/pull/149 is merged.
+	return nil
+}
+
+func (f *FakeURLMapSyncer) AddStatus(lbName string) {
+	for i, um := range f.EnsuredURLMaps {
+		if um.LBName == lbName {
+			f.EnsuredURLMaps[i].HasStatus = true
+		}
+	}
+}
+
+func (f *FakeURLMapSyncer) RemoveStatus(lbName string) {
+	for i, um := range f.EnsuredURLMaps {
+		if um.LBName == lbName {
+			f.EnsuredURLMaps[i].HasStatus = false
+		}
+	}
 }

--- a/app/kubemci/pkg/gcp/urlmap/interfaces.go
+++ b/app/kubemci/pkg/gcp/urlmap/interfaces.go
@@ -37,4 +37,6 @@ type URLMapSyncerInterface interface {
 	GetLoadBalancerStatus(lbName string) (*status.LoadBalancerStatus, error)
 	// ListLoadBalancerStatuses returns status of all MCI ingresses (load balancers) that have statuses stored on url maps.
 	ListLoadBalancerStatuses() ([]status.LoadBalancerStatus, error)
+	// RemoveClustersFromStatus removes the given clusters from the LoadBalancerStatus.
+	RemoveClustersFromStatus(clusters []string) error
 }


### PR DESCRIPTION
Ref https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/58 (remove-clusters) and https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/145 (storing status on url map instead of forwarding rule).

Follow up to https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/pull/146 which added a `kubemci remove-clusters` command. That PR updated the status stored on forwarding rule.
This PR updates that code to update the status on url map as well.

The status could be stored on forwarding rule (for old MCIs) or url map (for new MCIs).

cc @G-Harmon @csbell @madhusudancs 