### PR TITLE
Fixing targetproxy deletion to not return an error when it does not exist

### DIFF
--- a/app/kubemci/pkg/gcp/backendservice/backendservicesyncer_test.go
+++ b/app/kubemci/pkg/gcp/backendservice/backendservicesyncer_test.go
@@ -143,6 +143,10 @@ func TestDeleteBackendService(t *testing.T) {
 			SvcName:  types.NamespacedName{Name: kubeSvcName},
 		},
 	}
+	// Verify that trying to delete when no backend service exists does not return any error.
+	if err := bss.DeleteBackendServices(ports); err != nil {
+		t.Fatalf("unexpected error in deleting backend services when none exist: %s", err)
+	}
 	if _, err := bss.EnsureBackendService(lbName, ports, healthcheck.HealthChecksMap{
 		port: &compute.HealthCheck{
 			SelfLink: hcLink,

--- a/app/kubemci/pkg/gcp/firewallrule/firewallrulesyncer_test.go
+++ b/app/kubemci/pkg/gcp/firewallrule/firewallrulesyncer_test.go
@@ -130,6 +130,10 @@ func TestDeleteFirewallRule(t *testing.T) {
 	if _, err := fwp.GetFirewall(fwName); err == nil {
 		t.Fatalf("expected NotFound error, actual: nil")
 	}
+	// Verify that trying to delete when no firewall rule exists does not return any error.
+	if err := fws.DeleteFirewallRules(); err != nil {
+		t.Fatalf("unexpected error in deleting firewall rules when none exist: %s", err)
+	}
 	err := fws.EnsureFirewallRule(lbName, []ingressbe.ServicePort{
 		{
 			NodePort: port,

--- a/app/kubemci/pkg/gcp/forwardingrule/forwardingrulesyncer_test.go
+++ b/app/kubemci/pkg/gcp/forwardingrule/forwardingrulesyncer_test.go
@@ -461,6 +461,10 @@ func TestDeleteForwardingRule(t *testing.T) {
 	httpFrName := namer.HttpForwardingRuleName()
 	httpsFrName := namer.HttpsForwardingRuleName()
 	frs := NewForwardingRuleSyncer(namer, frp)
+	// Verify that trying to delete when no rule exists does not return any error.
+	if err := frs.DeleteForwardingRules(); err != nil {
+		t.Fatalf("unexpeted error in deleting forwarding rules when none exist: %s", err)
+	}
 	// Create both the http and https forwarding rules and verify that it deletes both.
 	if err := frs.EnsureHttpForwardingRule(lbName, ipAddr, tpLink, false /*force*/); err != nil {
 		t.Fatalf("expected no error in ensuring http forwarding rule, actual: %v", err)

--- a/app/kubemci/pkg/gcp/healthcheck/healthchecksyncer_test.go
+++ b/app/kubemci/pkg/gcp/healthcheck/healthchecksyncer_test.go
@@ -249,6 +249,10 @@ func TestDeleteHealthCheck(t *testing.T) {
 			Protocol: annotations.ProtocolHTTP,
 		},
 	}
+	// Verify that trying to delete when no check exists does not return any error.
+	if err := hcs.DeleteHealthChecks(ports); err != nil {
+		t.Fatalf("unexpected error in deleting health checks when none exist: %s", err)
+	}
 	if _, err := hcs.EnsureHealthCheck(lbName, ports, map[string]kubernetes.Interface{"client1": &clientfake.Clientset{}}, false); err != nil {
 		t.Fatalf("unexpected error in ensuring health checks: %s", err)
 	}

--- a/app/kubemci/pkg/gcp/targetproxy/targetproxysyncer.go
+++ b/app/kubemci/pkg/gcp/targetproxy/targetproxysyncer.go
@@ -93,7 +93,7 @@ func (s *TargetProxySyncer) DeleteTargetProxies() error {
 	fmt.Println("Deleting target HTTPS proxy", httpsName)
 	httpsErr := s.tpp.DeleteTargetHttpsProxy(httpsName)
 	if httpsErr != nil {
-		if utils.IsHTTPErrorCode(err, http.StatusNotFound) {
+		if utils.IsHTTPErrorCode(httpsErr, http.StatusNotFound) {
 			fmt.Println("Target HTTPS proxy", httpsName, "does not exist. Nothing to delete")
 		} else {
 			httpsErr = fmt.Errorf("error in deleting target HTTPS proxy %s: %s", httpsName, httpsErr)

--- a/app/kubemci/pkg/gcp/targetproxy/targetproxysyncer_test.go
+++ b/app/kubemci/pkg/gcp/targetproxy/targetproxysyncer_test.go
@@ -173,12 +173,16 @@ func TestDeleteTargetProxies(t *testing.T) {
 	lbName := "lb-name"
 	umLink := "selfLink"
 	certLink := "certSelfLink"
-	// Create both http and https and verify that it deletes both.
 	tpp := ingresslb.NewFakeLoadBalancers("" /*name*/, nil /*namer*/)
 	namer := utilsnamer.NewNamer("mci1", lbName)
 	httpTpName := namer.TargetHttpProxyName()
 	httpsTpName := namer.TargetHttpsProxyName()
 	tps := NewTargetProxySyncer(namer, tpp)
+	// Verify that trying to delete when no proxy exists does not return any error.
+	if err := tps.DeleteTargetProxies(); err != nil {
+		t.Errorf("unexpected error in deleting target proxies when none exist: %s", err)
+	}
+	// Create both http and https and verify that it deletes both.
 	if _, err := tps.EnsureHttpTargetProxy(lbName, umLink, false /*forceUpdate*/); err != nil {
 		t.Fatalf("expected no error in ensuring http target proxy, actual: %v", err)
 	}

--- a/app/kubemci/pkg/gcp/urlmap/urlmapsyncer_test.go
+++ b/app/kubemci/pkg/gcp/urlmap/urlmapsyncer_test.go
@@ -145,6 +145,10 @@ func TestDeleteURLMap(t *testing.T) {
 	ump := ingresslb.NewFakeLoadBalancers("" /*name*/, ingressNamer)
 	umName := namer.URLMapName()
 	ums := NewURLMapSyncer(namer, ump)
+	// Verify that trying to delete when no map exists does not return any error.
+	if err := ums.DeleteURLMap(); err != nil {
+		t.Fatalf("unexpected err while deleting URL map when none exist: %s", err)
+	}
 	if _, err := ums.EnsureURLMap(lbName, ipAddr, clusters, ing, beMap, false /*forceUpdate*/); err != nil {
 		t.Fatalf("expected no error in ensuring url map, actual: %v", err)
 	}


### PR DESCRIPTION
Ref https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/155

Also added tests to ensure that we do not regress.
The tests wont fail however, until we update the ingress-gce fakes to return NotFound as expected (details in issue)

cc @G-Harmon @csbell 