### PR TITLE
Adding more unit tests for remove-clusters

### DIFF
--- a/app/kubemci/pkg/gcp/firewallrule/fake_firewallrulesyncer.go
+++ b/app/kubemci/pkg/gcp/firewallrule/fake_firewallrulesyncer.go
@@ -52,7 +52,7 @@ func (h *FakeFirewallRuleSyncer) DeleteFirewallRules() error {
 }
 
 func (h *FakeFirewallRuleSyncer) RemoveFromClusters(lbName string, removeIGLinks map[string][]string) error {
-	for _, v := range h.EnsuredFirewallRules {
+	for i, v := range h.EnsuredFirewallRules {
 		if v.LBName != lbName {
 			continue
 		}
@@ -62,7 +62,7 @@ func (h *FakeFirewallRuleSyncer) RemoveFromClusters(lbName string, removeIGLinks
 				newIGLinks[clusterName] = igValues
 			}
 		}
-		v.IGLinks = newIGLinks
+		h.EnsuredFirewallRules[i].IGLinks = newIGLinks
 	}
 	return nil
 }

--- a/app/kubemci/pkg/gcp/forwardingrule/fake_forwardingrulesyncer.go
+++ b/app/kubemci/pkg/gcp/forwardingrule/fake_forwardingrulesyncer.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/status"
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/goutils"
 )
 
 type FakeForwardingRule struct {
@@ -88,17 +89,14 @@ func (f *FakeForwardingRuleSyncer) ListLoadBalancerStatuses() ([]status.LoadBala
 }
 
 func (f *FakeForwardingRuleSyncer) RemoveClustersFromStatus(clusters []string) error {
-	removeClusters := make(map[string]bool, len(clusters))
-	for _, c := range clusters {
-		removeClusters[c] = true
-	}
+	clustersToRemove := goutils.MapFromSlice(clusters)
 	for i, fr := range f.EnsuredForwardingRules {
 		if fr.Status == nil {
 			continue
 		}
 		newClusters := []string{}
 		for _, c := range fr.Status.Clusters {
-			if _, has := removeClusters[c]; !has {
+			if _, has := clustersToRemove[c]; !has {
 				newClusters = append(newClusters, c)
 			}
 		}

--- a/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
+++ b/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
@@ -345,27 +345,36 @@ func (l *LoadBalancerSyncer) removeClustersFromStatus(lbName string, clustersToR
 
 // PrintStatus prints the current status of the load balancer.
 func (l *LoadBalancerSyncer) PrintStatus() (string, error) {
+	status, err := l.getLoadBalancerStatus()
+	if err != nil {
+		return "", err
+	}
+	return formatLoadBalancerStatus(l.lbName, *status), nil
+}
+
+// getLoadBalancerStatus returns the current status of the load balancer.
+func (l *LoadBalancerSyncer) getLoadBalancerStatus() (*status.LoadBalancerStatus, error) {
 	// First try to fetch the status from url map.
 	// If that fails, then we fetch it from forwarding rule.
 	// This is because we first used to store the status on forwarding rules and then migrated to url maps.
 	// https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/145 has more details.
-	sd, umErr := l.ums.GetLoadBalancerStatus(l.lbName)
-	if umErr == nil {
-		return formatLoadBalancerStatus(l.lbName, *sd), nil
+	umStatus, umErr := l.ums.GetLoadBalancerStatus(l.lbName)
+	if umStatus != nil && umErr == nil {
+		return umStatus, nil
 	}
 	if ingressutils.IsHTTPErrorCode(umErr, http.StatusNotFound) {
-		return "", fmt.Errorf("Load balancer %s does not exist", l.lbName)
+		return nil, fmt.Errorf("Load balancer %s does not exist", l.lbName)
 	}
 	// Try forwarding rule.
-	sd, frErr := l.frs.GetLoadBalancerStatus(l.lbName)
-	if frErr == nil {
-		return formatLoadBalancerStatus(l.lbName, *sd), nil
+	frStatus, frErr := l.frs.GetLoadBalancerStatus(l.lbName)
+	if frStatus != nil && frErr == nil {
+		return frStatus, nil
 	}
 	if ingressutils.IsHTTPErrorCode(frErr, http.StatusNotFound) {
-		return "", fmt.Errorf("Load balancer %s does not exist", l.lbName)
+		return nil, fmt.Errorf("Load balancer %s does not exist", l.lbName)
 	}
 	// Failed to get status from both url map and forwarding rule.
-	return "", fmt.Errorf("failed to get status from both url map and forwarding rule. Error in extracting status from url map: %s. Error in extracting status from forwarding rule: %s", umErr, frErr)
+	return nil, fmt.Errorf("failed to get status from both url map and forwarding rule. Error in extracting status from url map: %s. Error in extracting status from forwarding rule: %s", umErr, frErr)
 }
 
 // formatLoadBalancerStatus formats the given status to be printed for get-status output.

--- a/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer_test.go
+++ b/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer_test.go
@@ -367,6 +367,10 @@ func TestDeleteLoadBalancer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error in test setup: %s", err)
 	}
+	// Verify that trying to delete when no load balancer exists does not return any error.
+	if err := lbc.DeleteLoadBalancer(ing); err != nil {
+		t.Fatalf("unexpected error while deleting load balancer when none exist: %s", err)
+	}
 	if err := lbc.CreateLoadBalancer(ing, true /*forceUpdate*/, true /*validate*/, clusters); err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}
@@ -424,6 +428,7 @@ func TestRemoveFromClusters(t *testing.T) {
 	igName := "my-fake-ig"
 	igZone := "my-fake-zone"
 	zoneLink := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/fake-project/zones/%s", igZone)
+	igLink := fmt.Sprintf("%s/instanceGroups/%s", zoneLink, igName)
 	clusters := []string{"cluster1", "cluster2"}
 	lbc := newLoadBalancerSyncer(lbName)
 	ipAddress := &compute.Address{
@@ -439,38 +444,32 @@ func TestRemoveFromClusters(t *testing.T) {
 	if err := lbc.CreateLoadBalancer(ing, true /*forceUpdate*/, true /*validate*/, clusters); err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}
-	fhc := lbc.hcs.(*healthcheck.FakeHealthCheckSyncer)
-	if len(fhc.EnsuredHealthChecks) == 0 {
-		t.Errorf("unexpected health checks not created")
-	}
+	// Verify that backend service, firewall rule and status are as expected.
 	fbs := lbc.bss.(*backendservice.FakeBackendServiceSyncer)
-	if len(fbs.EnsuredBackendServices) == 0 {
-		t.Errorf("unexpected backend services not created")
+	if len(fbs.EnsuredBackendServices) != 2 {
+		t.Errorf("unexpected backend services, expected 2 backend services, got: %v", fbs.EnsuredBackendServices)
 	}
-	fum := lbc.ums.(*urlmap.FakeURLMapSyncer)
-	if len(fum.EnsuredURLMaps) == 0 {
-		t.Errorf("unexpected url maps not created")
+	expectedIGlinks := []string{igLink, igLink}
+	if err := verifyBackendService(fbs.EnsuredBackendServices[0], expectedIGlinks); err != nil {
+		t.Errorf("%s", err)
 	}
-	ftp := lbc.tps.(*targetproxy.FakeTargetProxySyncer)
-	if len(ftp.EnsuredTargetProxies) == 0 {
-		t.Errorf("unexpected target proxies not created")
-	}
-	ffr := lbc.frs.(*forwardingrule.FakeForwardingRuleSyncer)
-	if len(ffr.EnsuredForwardingRules) == 0 {
-		t.Errorf("unexpected forwarding rules not created")
+	if err := verifyBackendService(fbs.EnsuredBackendServices[1], expectedIGlinks); err != nil {
+		t.Errorf("%s", err)
 	}
 	ffw := lbc.fws.(*firewallrule.FakeFirewallRuleSyncer)
-	if len(ffw.EnsuredFirewallRules) == 0 {
-		t.Errorf("unexpected firewall rules not created")
+	if len(ffw.EnsuredFirewallRules) != 1 {
+		t.Errorf("unexpected firewall rules, expected 1, got: %v", ffw.EnsuredFirewallRules)
 	}
-	// Add status to the forwarding rule to simulate old forwarding rule which has status.
-	// TODO: This should not be required once lbc.RemoveFromClusters can update url map status:
-	// https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/pull/151
-	typedFRS := lbc.frs.(*forwardingrule.FakeForwardingRuleSyncer)
-	typedFRS.AddStatus(lbName, &status.LoadBalancerStatus{Clusters: clusters})
-
+	fw := ffw.EnsuredFirewallRules[0]
+	expectedFWIGLinks := map[string][]string{
+		"cluster1": []string{igLink},
+		"cluster2": []string{igLink},
+	}
+	if !reflect.DeepEqual(fw.IGLinks, expectedFWIGLinks) {
+		t.Errorf("unexpected IG links on firewall rule, expected: %v, got: %v", expectedFWIGLinks, fw.IGLinks)
+	}
 	// Verify that the load balancer is spread to both clusters.
-	if err := verifyClusters(lbName, lbc.frs, clusters); err != nil {
+	if err := verifyClusters(lbc, clusters); err != nil {
 		t.Errorf("%s", err)
 	}
 
@@ -481,7 +480,29 @@ func TestRemoveFromClusters(t *testing.T) {
 	if err := lbc.RemoveFromClusters(ing, removeClients, false /*forceUpdate*/); err != nil {
 		t.Errorf("unexpected error in removing existing load balancer from clusters: %s", err)
 	}
-	if err := verifyClusters(lbName, lbc.frs, []string{"cluster2"}); err != nil {
+
+	// Verify that the backend service, firewall rule and status are updated as expected.
+	if len(fbs.EnsuredBackendServices) != 2 {
+		t.Errorf("unexpected backend services, expected 2 backend services, got: %v", fbs.EnsuredBackendServices)
+	}
+	expectedIGlinks = []string{igLink}
+	if err := verifyBackendService(fbs.EnsuredBackendServices[0], expectedIGlinks); err != nil {
+		t.Errorf("%s", err)
+	}
+	if err := verifyBackendService(fbs.EnsuredBackendServices[1], expectedIGlinks); err != nil {
+		t.Errorf("err: %s\nEnsuredBackendServices: %v", err, fbs.EnsuredBackendServices)
+	}
+	if len(ffw.EnsuredFirewallRules) != 1 {
+		t.Errorf("unexpected firewall rules, expected 1, got: %v", ffw.EnsuredFirewallRules)
+	}
+	fw = ffw.EnsuredFirewallRules[0]
+	expectedFWIGLinks = map[string][]string{
+		"cluster2": []string{igLink},
+	}
+	if !reflect.DeepEqual(fw.IGLinks, expectedFWIGLinks) {
+		t.Errorf("unexpected IG links on firewall rule, expected: %v, got: %v", expectedFWIGLinks, fw.IGLinks)
+	}
+	if err := verifyClusters(lbc, []string{"cluster2"}); err != nil {
 		t.Errorf("%s", err)
 	}
 
@@ -489,6 +510,13 @@ func TestRemoveFromClusters(t *testing.T) {
 	if err := lbc.DeleteLoadBalancer(ing); err != nil {
 		t.Fatalf("unexpected error in deleting load balancer: %s", err)
 	}
+}
+
+func verifyBackendService(be backendservice.FakeBackendService, expectedIGlinks []string) error {
+	if !reflect.DeepEqual(be.IGLinks, expectedIGlinks) {
+		return fmt.Errorf("unexpected IG links on backend service. expected: %v, got: %v", expectedIGlinks, be.IGLinks)
+	}
+	return nil
 }
 
 func TestRemoveClustersFromStatus(t *testing.T) {
@@ -516,14 +544,15 @@ func TestRemoveClustersFromStatus(t *testing.T) {
 	}{
 		{
 			// Default case.
-			true,
 			false,
+			true,
 			false,
 		},
 		{
-			false,
+			// Old setup - forwarding rule has the status, url map does not.
 			true,
-			true, // TODO: Update this to false when GetLoadBalancerStatus can read from url map.
+			false,
+			false,
 		},
 		{
 			true,
@@ -541,18 +570,16 @@ func TestRemoveClustersFromStatus(t *testing.T) {
 			t.Fatalf("unexpected error %s", err)
 		}
 		if c.frHasStatus {
+			// Explicitly add status, since forwarding rule will not have status by default.
 			lbc.frs.(*forwardingrule.FakeForwardingRuleSyncer).AddStatus(lbName, &status.LoadBalancerStatus{Clusters: clusters})
 		}
 		if !c.umHasStatus {
+			// Explicitly remove status, since url map will have status by default.
 			lbc.ums.(*urlmap.FakeURLMapSyncer).RemoveStatus(lbName)
 		}
 		// Verify that the load balancer is spread to both clusters.
-		// TODO: Remove this if once we update GetLoadBalancerStatus to read from urlmap as well.
-		if c.frHasStatus {
-
-			if err := verifyClusters(lbName, lbc.frs, clusters); c.errorInGetStatus != (err != nil) {
-				t.Errorf("expected error in verifying status: %v, got err: %s", c.errorInGetStatus, err)
-			}
+		if err := verifyClusters(lbc, clusters); c.errorInGetStatus != (err != nil) {
+			t.Errorf("expected error in verifying status: %v, got err: %s", c.errorInGetStatus, err)
 		}
 
 		// Remove the load balancer from the first cluster and verify that the load balancer status is updated appropriately.
@@ -560,12 +587,9 @@ func TestRemoveClustersFromStatus(t *testing.T) {
 		if err := lbc.removeClustersFromStatus(lbName, clustersToRemove); err != nil {
 			t.Errorf("unexpected error in removing existing load balancer from clusters: %s", err)
 		}
-		// TODO: Remove this if once we update GetLoadBalancerStatus to read from urlmap as well.
-		if c.frHasStatus {
-			if err := verifyClusters(lbName, lbc.frs, []string{"cluster2"}); c.errorInGetStatus != (err != nil) {
+		if err := verifyClusters(lbc, []string{"cluster2"}); c.errorInGetStatus != (err != nil) {
 
-				t.Errorf("expected error in verifying status: %v, got err: %s", c.errorInGetStatus, err)
-			}
+			t.Errorf("expected error in verifying status: %v, got err: %s", c.errorInGetStatus, err)
 		}
 		if err := lbc.DeleteLoadBalancer(ing); err != nil {
 			t.Fatalf("unexpected error %s", err)
@@ -573,8 +597,8 @@ func TestRemoveClustersFromStatus(t *testing.T) {
 	}
 }
 
-func verifyClusters(lbName string, frs forwardingrule.ForwardingRuleSyncerInterface, expectedClusters []string) error {
-	status, err := frs.GetLoadBalancerStatus(lbName)
+func verifyClusters(lbc *LoadBalancerSyncer, expectedClusters []string) error {
+	status, err := lbc.getLoadBalancerStatus()
 	if status == nil || err != nil {
 		return fmt.Errorf("unexpected error in getting load balancer status: %s", err)
 	}


### PR DESCRIPTION
Ref https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/58 and https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/145

Fixing TODOs from https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/pull/151 and https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/pull/149

Adding more unit tests for remove-clusters command.
Bulk of the PR is unit test changes, with minor bug fixes.

cc @csbell @G-Harmon @madhusudancs @perotinus

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/158)
<!-- Reviewable:end -->
