### PR TITLE
Add --force to delete to allow users to force delete whatever can be deleted

### DIFF
--- a/app/kubemci/cmd/delete.go
+++ b/app/kubemci/cmd/delete.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 	"k8s.io/api/extensions/v1beta1"
 	// gcp is needed for GKE cluster auth to work.
@@ -52,6 +53,8 @@ type DeleteOptions struct {
 	// Required
 	// TODO(nikhiljindal): This should be optional. Figure it out from gcloud settings.
 	GCPProject string
+	// Delete whatever can be deleted in case of errors.
+	ForceDelete bool
 	// Name of the namespace for the ingress when none is provided (mismatch of option with spec causes an error).
 	// Optional.
 	Namespace string
@@ -85,6 +88,7 @@ func addDeleteFlags(cmd *cobra.Command, options *DeleteOptions) error {
 	cmd.Flags().StringSliceVar(&options.KubeContexts, "kubecontexts", options.KubeContexts, "[optional] contexts in the kubeconfig file to delete the ingress from")
 	// TODO(nikhiljindal): Add a short flag "-p" if it seems useful.
 	cmd.Flags().StringVarP(&options.GCPProject, "gcp-project", "", options.GCPProject, "[optional] name of the gcp project. Is fetched using gcloud config get-value project if unset here")
+	cmd.Flags().BoolVarP(&options.ForceDelete, "force", "f", options.ForceDelete, "[optional] delete whatever can be deleted in case of errors. This should only be used in exceptional cases (for example: when the clusters are deleted before the ingress was deleted)")
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", options.Namespace, "[optional] namespace for the ingress only if left unspecified by ingress spec")
 	// TODO Add a verbose flag that turns on glog logging.
 	return nil
@@ -113,29 +117,34 @@ func validateDeleteArgs(options *DeleteOptions, args []string) error {
 
 func runDelete(options *DeleteOptions, args []string) error {
 	options.LBName = args[0]
+	var err error
 
 	// Unmarshal the YAML into ingress struct.
 	var ing v1beta1.Ingress
-	if err := ingress.UnmarshallAndApplyDefaults(options.IngressFilename, options.Namespace, &ing); err != nil {
-		return fmt.Errorf("error in unmarshalling the yaml file %s, err: %s", options.IngressFilename, err)
+	if ingErr := ingress.UnmarshallAndApplyDefaults(options.IngressFilename, options.Namespace, &ing); ingErr != nil {
+		return fmt.Errorf("error in unmarshalling the yaml file %s, err: %s", options.IngressFilename, ingErr)
 	}
-	cloudInterface, err := cloudinterface.NewGCECloudInterface(options.GCPProject)
-	if err != nil {
-		return fmt.Errorf("error in creating cloud interface: %s", err)
+	cloudInterface, ciErr := cloudinterface.NewGCECloudInterface(options.GCPProject)
+	if ciErr != nil {
+		return fmt.Errorf("error in creating cloud interface: %s", ciErr)
 	}
 
 	// Get clients for all clusters
-	clients, err := kubeutils.GetClients(options.KubeconfigFilename, options.KubeContexts)
-	if err != nil {
-		return err
+	clients, clientsErr := kubeutils.GetClients(options.KubeconfigFilename, options.KubeContexts)
+	if clientsErr != nil {
+		return clientsErr
 	}
 
-	lbs, err := gcplb.NewLoadBalancerSyncer(options.LBName, clients, cloudInterface, options.GCPProject)
-	if err != nil {
-		return err
+	lbs, lbErr := gcplb.NewLoadBalancerSyncer(options.LBName, clients, cloudInterface, options.GCPProject)
+	if lbErr != nil {
+		return lbErr
 	}
-	if delErr := lbs.DeleteLoadBalancer(&ing); delErr != nil {
-		return delErr
+	if delErr := lbs.DeleteLoadBalancer(&ing, options.ForceDelete); delErr != nil {
+		if !options.ForceDelete {
+			return delErr
+		}
+		fmt.Printf("%s. Continuing with force delete\n", delErr)
+		err = multierror.Append(err, delErr)
 	}
 
 	// Delete ingress resource in clusters
@@ -143,10 +152,13 @@ func runDelete(options *DeleteOptions, args []string) error {
 	// This is to ensure that the backend service is deleted when ingress-gce controller
 	// observes ingress deletion and hence tries to delete instance groups.
 	// https://github.com/kubernetes/ingress-gce/issues/186 has more details.
-	err = ingress.NewIngressSyncer().DeleteIngress(&ing, clients)
-	if err != nil {
-		return err
+	isErr := ingress.NewIngressSyncer().DeleteIngress(&ing, clients)
+	if isErr != nil {
+		if !options.ForceDelete {
+			return isErr
+		}
+		fmt.Printf("%s. Continuing with force delete\n", isErr)
+		err = multierror.Append(err, isErr)
 	}
-
 	return err
 }

--- a/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
+++ b/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
@@ -227,15 +227,19 @@ func (l *LoadBalancerSyncer) CreateLoadBalancer(ing *v1beta1.Ingress, forceUpdat
 }
 
 // DeleteLoadBalancer deletes the GCP resources associated with the L7 GCP load balancer for the given ingress.
+// Continues in case of errors and deletes the resources that it can when forceDelete is set to true.
 // TODO(nikhiljindal): Do not require the ingress yaml from users. Just the name should be enough. We can fetch ingress YAML from one of the clusters.
-func (l *LoadBalancerSyncer) DeleteLoadBalancer(ing *v1beta1.Ingress) error {
+func (l *LoadBalancerSyncer) DeleteLoadBalancer(ing *v1beta1.Ingress, forceDelete bool) error {
+	var err error
 	client, cErr := getAnyClient(l.clients)
 	if cErr != nil {
-		// No point in continuing without a client.
-		return cErr
+		if !forceDelete {
+			// No point in continuing without a client.
+			return cErr
+		}
+		fmt.Printf("%s. Continuing with force delete. Will not be able to delete backend services and healthchecks\n", cErr)
+		err = multierror.Append(err, cErr)
 	}
-	ports := l.ingToNodePorts(ing, client)
-	var err error
 	// We delete resources in the reverse order in which they were created.
 	// For ex: we create health checks before creating backend services (so that backend service can point to the health check),
 	// but delete backend service before deleting health check. We cannot delete the health check when backend service is still pointing to it.
@@ -260,13 +264,16 @@ func (l *LoadBalancerSyncer) DeleteLoadBalancer(ing *v1beta1.Ingress) error {
 		// Aggregate errors and return all at the end.
 		err = multierror.Append(err, umErr)
 	}
-	if beErr := l.bss.DeleteBackendServices(ports); beErr != nil {
-		// Aggregate errors and return all at the end.
-		err = multierror.Append(err, beErr)
-	}
-	if hcErr := l.hcs.DeleteHealthChecks(ports); hcErr != nil {
-		// Aggregate errors and return all at the end.
-		err = multierror.Append(err, hcErr)
+	if cErr == nil {
+		ports := l.ingToNodePorts(ing, client)
+		if beErr := l.bss.DeleteBackendServices(ports); beErr != nil {
+			// Aggregate errors and return all at the end.
+			err = multierror.Append(err, beErr)
+		}
+		if hcErr := l.hcs.DeleteHealthChecks(ports); hcErr != nil {
+			// Aggregate errors and return all at the end.
+			err = multierror.Append(err, hcErr)
+		}
 	}
 	return err
 }


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/164

Adding a `--force` flag to kubemci delete to continue deletion even in case of errors.

Will add an e2e test as part of remove-clusters test (delete the mci after it has been removed from all clusters) 

cc @G-Harmon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/168)
<!-- Reviewable:end -->
