### PR TITLE
Prompting user to delete mci when all clusters are removed

### DIFF
--- a/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
+++ b/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
@@ -274,6 +274,19 @@ func (l *LoadBalancerSyncer) DeleteLoadBalancer(ing *v1beta1.Ingress) error {
 // RemoveFromClusters removes the given ingress from the clusters corresponding to the given clients.
 // TODO(nikhiljindal): Do not require the ingress yaml from users. Just the name should be enough. We can fetch ingress YAML from one of the clusters.
 func (l *LoadBalancerSyncer) RemoveFromClusters(ing *v1beta1.Ingress, removeClients map[string]kubeclient.Interface, forceUpdate bool) error {
+	// First verify that removing it from the given clusters will not remove it from all clusters.
+	// If yes, then prompt users to use delete instead or use --force.
+	lbStatus, statusErr := l.getLoadBalancerStatus()
+	if statusErr != nil {
+		return fmt.Errorf("error in fetching status of existing load balancer: %s", statusErr)
+	}
+	if !hasSomeRemainingClusters(lbStatus.Clusters, removeClients) {
+		if !forceUpdate {
+			return fmt.Errorf("This will remove the ingress from all clusters. You should use kubemci delete to delete the ingress completely. If you really want to just remove it from existing clusters without deleting it completely, use --force flag with remove-clusters command")
+		}
+		fmt.Println("This will remove the ingress from all clusters. Continuing with force update")
+	}
+
 	client, cErr := getAnyClient(l.clients)
 	if cErr != nil {
 		// No point in continuing without a client.
@@ -282,31 +295,35 @@ func (l *LoadBalancerSyncer) RemoveFromClusters(ing *v1beta1.Ingress, removeClie
 	var err error
 	ports := l.ingToNodePorts(ing, client)
 	removeIGLinks, igErr := l.getIGs(ing, removeClients)
+	if igErr == nil && len(removeIGLinks) == 0 {
+		igErr = fmt.Errorf("No instance group found")
+	}
+	// Can not really update resources without igs. So return on error.
+	// Allow users to continue using force since they can run into this if they are trying to remove their already deleted clusters.
 	if igErr != nil {
-		return multierror.Append(err, igErr)
-	}
-	// Can not really update any resource without igs. No point continuing.
-	// Note: User can run into this if they are trying to remove their already deleted clusters.
-	// TODO: Allow them to proceed to clean up whatever they can by using --force.
-	if len(removeIGLinks) == 0 {
-		err := multierror.Append(err, fmt.Errorf("No instance group found. Can not continue"))
-		return err
+		if !forceUpdate {
+			return igErr
+		}
+		fmt.Printf("Error in fetching instance groups: %s. Continuing with force update\n", igErr)
+		err = multierror.Append(err, igErr)
 	}
 
-	if fwErr := l.fws.RemoveFromClusters(l.lbName, removeIGLinks); fwErr != nil {
-		// Aggregate errors and return all at the end.
-		err = multierror.Append(err, fwErr)
-	}
+	if igErr == nil {
+		if fwErr := l.fws.RemoveFromClusters(l.lbName, removeIGLinks); fwErr != nil {
+			// Aggregate errors and return all at the end.
+			err = multierror.Append(err, fwErr)
+		}
 
-	// Convert the map of instance groups to a flat array.
-	igsForBE := []string{}
-	for k := range removeIGLinks {
-		igsForBE = append(igsForBE, removeIGLinks[k]...)
-	}
+		// Convert the map of instance groups to a flat array.
+		igsForBE := []string{}
+		for k := range removeIGLinks {
+			igsForBE = append(igsForBE, removeIGLinks[k]...)
+		}
 
-	if beErr := l.bss.RemoveFromClusters(ports, igsForBE); beErr != nil {
-		// Aggregate errors and return all at the end.
-		err = multierror.Append(err, beErr)
+		if beErr := l.bss.RemoveFromClusters(ports, igsForBE); beErr != nil {
+			// Aggregate errors and return all at the end.
+			err = multierror.Append(err, beErr)
+		}
 	}
 
 	// Convert the client map to an array of cluster names.
@@ -322,6 +339,16 @@ func (l *LoadBalancerSyncer) RemoveFromClusters(ing *v1beta1.Ingress, removeClie
 		err = multierror.Append(err, statusErr)
 	}
 	return err
+}
+
+// hasSomeRemainingClusters returns true if not all clusters are in the clustersToRemove list.
+func hasSomeRemainingClusters(clusters []string, clustersToRemove map[string]kubeclient.Interface) bool {
+	for _, v := range clusters {
+		if _, has := clustersToRemove[v]; !has {
+			return true
+		}
+	}
+	return false
 }
 
 // removeClustersFromStatus updates the status of the given load balancer to remove the given list of clusters from it.

--- a/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer_test.go
+++ b/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer_test.go
@@ -445,31 +445,13 @@ func TestRemoveFromClusters(t *testing.T) {
 		t.Fatalf("unexpected error %s", err)
 	}
 	// Verify that backend service, firewall rule and status are as expected.
-	fbs := lbc.bss.(*backendservice.FakeBackendServiceSyncer)
-	if len(fbs.EnsuredBackendServices) != 2 {
-		t.Errorf("unexpected backend services, expected 2 backend services, got: %v", fbs.EnsuredBackendServices)
-	}
+	expectedClusters := clusters
 	expectedIGlinks := []string{igLink, igLink}
-	if err := verifyBackendService(fbs.EnsuredBackendServices[0], expectedIGlinks); err != nil {
-		t.Errorf("%s", err)
-	}
-	if err := verifyBackendService(fbs.EnsuredBackendServices[1], expectedIGlinks); err != nil {
-		t.Errorf("%s", err)
-	}
-	ffw := lbc.fws.(*firewallrule.FakeFirewallRuleSyncer)
-	if len(ffw.EnsuredFirewallRules) != 1 {
-		t.Errorf("unexpected firewall rules, expected 1, got: %v", ffw.EnsuredFirewallRules)
-	}
-	fw := ffw.EnsuredFirewallRules[0]
 	expectedFWIGLinks := map[string][]string{
 		"cluster1": []string{igLink},
 		"cluster2": []string{igLink},
 	}
-	if !reflect.DeepEqual(fw.IGLinks, expectedFWIGLinks) {
-		t.Errorf("unexpected IG links on firewall rule, expected: %v, got: %v", expectedFWIGLinks, fw.IGLinks)
-	}
-	// Verify that the load balancer is spread to both clusters.
-	if err := verifyClusters(lbc, clusters); err != nil {
+	if err := verifyRemoveClustersResult(lbc, expectedClusters, expectedIGlinks, expectedFWIGLinks); err != nil {
 		t.Errorf("%s", err)
 	}
 
@@ -480,29 +462,35 @@ func TestRemoveFromClusters(t *testing.T) {
 	if err := lbc.RemoveFromClusters(ing, removeClients, false /*forceUpdate*/); err != nil {
 		t.Errorf("unexpected error in removing existing load balancer from clusters: %s", err)
 	}
-
-	// Verify that the backend service, firewall rule and status are updated as expected.
-	if len(fbs.EnsuredBackendServices) != 2 {
-		t.Errorf("unexpected backend services, expected 2 backend services, got: %v", fbs.EnsuredBackendServices)
-	}
+	expectedClusters = []string{"cluster2"}
 	expectedIGlinks = []string{igLink}
-	if err := verifyBackendService(fbs.EnsuredBackendServices[0], expectedIGlinks); err != nil {
-		t.Errorf("%s", err)
-	}
-	if err := verifyBackendService(fbs.EnsuredBackendServices[1], expectedIGlinks); err != nil {
-		t.Errorf("err: %s\nEnsuredBackendServices: %v", err, fbs.EnsuredBackendServices)
-	}
-	if len(ffw.EnsuredFirewallRules) != 1 {
-		t.Errorf("unexpected firewall rules, expected 1, got: %v", ffw.EnsuredFirewallRules)
-	}
-	fw = ffw.EnsuredFirewallRules[0]
 	expectedFWIGLinks = map[string][]string{
 		"cluster2": []string{igLink},
 	}
-	if !reflect.DeepEqual(fw.IGLinks, expectedFWIGLinks) {
-		t.Errorf("unexpected IG links on firewall rule, expected: %v, got: %v", expectedFWIGLinks, fw.IGLinks)
+	if err := verifyRemoveClustersResult(lbc, expectedClusters, expectedIGlinks, expectedFWIGLinks); err != nil {
+		t.Errorf("%s", err)
 	}
-	if err := verifyClusters(lbc, []string{"cluster2"}); err != nil {
+
+	// Try removing it from the second cluster as well and verify that it returns an error.
+	removeClients = map[string]kubeclient.Interface{
+		"cluster2": lbc.clients["cluster2"],
+	}
+	if err := lbc.RemoveFromClusters(ing, removeClients, false /*forceUpdate*/); err == nil {
+		t.Errorf("unexpected nil error in removing load balancer from all clusters, expected an error to prompt using delete command instead")
+	}
+	// Verify that nothing was changed.
+	if err := verifyRemoveClustersResult(lbc, expectedClusters, expectedIGlinks, expectedFWIGLinks); err != nil {
+		t.Errorf("%s", err)
+	}
+
+	// Verify that remove succeeds with force=true.
+	if err := lbc.RemoveFromClusters(ing, removeClients, true /*forceUpdate*/); err != nil {
+		t.Errorf("unexpected error in removing load balancer from all clusters with force=true: %s", err)
+	}
+	expectedClusters = []string{}
+	expectedIGlinks = []string{}
+	expectedFWIGLinks = map[string][]string{}
+	if err := verifyRemoveClustersResult(lbc, expectedClusters, expectedIGlinks, expectedFWIGLinks); err != nil {
 		t.Errorf("%s", err)
 	}
 
@@ -510,6 +498,34 @@ func TestRemoveFromClusters(t *testing.T) {
 	if err := lbc.DeleteLoadBalancer(ing); err != nil {
 		t.Fatalf("unexpected error in deleting load balancer: %s", err)
 	}
+}
+
+// verifyRemoveClustersResult verifies that backend services, firewall rules and load balancer status are as expected after a remove clusters command.
+// Returns an error if not true.
+func verifyRemoveClustersResult(lbc *LoadBalancerSyncer, expectedClusters, expectedIGlinks []string, expectedFWIGLinks map[string][]string) error {
+	fbs := lbc.bss.(*backendservice.FakeBackendServiceSyncer)
+	if len(fbs.EnsuredBackendServices) != 2 {
+		return fmt.Errorf("unexpected backend services, expected 2 backend services, got: %v", fbs.EnsuredBackendServices)
+	}
+	if err := verifyBackendService(fbs.EnsuredBackendServices[0], expectedIGlinks); err != nil {
+		return err
+	}
+	if err := verifyBackendService(fbs.EnsuredBackendServices[1], expectedIGlinks); err != nil {
+		return err
+	}
+	ffw := lbc.fws.(*firewallrule.FakeFirewallRuleSyncer)
+	if len(ffw.EnsuredFirewallRules) != 1 {
+		return fmt.Errorf("unexpected firewall rules, expected 1, got: %v", ffw.EnsuredFirewallRules)
+	}
+	fw := ffw.EnsuredFirewallRules[0]
+	if !reflect.DeepEqual(fw.IGLinks, expectedFWIGLinks) {
+		return fmt.Errorf("unexpected IG links on firewall rule, expected: %v, got: %v", expectedFWIGLinks, fw.IGLinks)
+	}
+	// Verify that the load balancer is spread to both clusters.
+	if err := verifyClusters(lbc, expectedClusters); err != nil {
+		return err
+	}
+	return nil
 }
 
 func verifyBackendService(be backendservice.FakeBackendService, expectedIGlinks []string) error {


### PR DESCRIPTION
Last PR for https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/58.

Updating remove-clusters command to require --force to remove the ingress from all existing clusters (as per discussion in https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/58#issuecomment-369081019).
Also using --force to continue in case of errors.

cc @G-Harmon 