### PR TITLE
Add a unit test for Validations.go: servicesNodePortsSame

### DIFF
--- a/app/kubemci/pkg/validations/validations.go
+++ b/app/kubemci/pkg/validations/validations.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 )
 
+// Validate performs pre-flight checks on the clusters and services.
 func Validate(clients map[string]kubeclient.Interface, ing *v1beta1.Ingress) error {
 	return servicesNodePortsSame(clients, ing)
 }
@@ -58,6 +59,7 @@ func servicesNodePortsSame(clients map[string]kubeclient.Interface, ing *v1beta1
 		}
 		glog.V(1).Infof("Default backend's nodeports passed validation.")
 	} else {
+		glog.V(1).Infof("Default backend is missing from Ingress Spec:\n%+v", ing.Spec)
 		multiErr = multierror.Append(multiErr, fmt.Errorf("unexpected: ing.spec.backend is nil. Multicluster ingress needs a user-specified default backend"))
 	}
 	return multiErr
@@ -74,7 +76,7 @@ func nodePortSameInAllClusters(backend v1beta1.IngressBackend, namespace string,
 
 		servicePort, err := kubeutils.GetServiceNodePort(backend, namespace, client)
 		if err != nil {
-			return fmt.Errorf("could not get service NodePort in cluster %s: %s", clientName, err)
+			return fmt.Errorf("could not get service NodePort in cluster '%s': %s", clientName, err)
 		}
 		glog.V(2).Infof("cluster %s: Service's servicePort: %+v", clientName, servicePort)
 		clusterNodePort := servicePort.NodePort
@@ -92,6 +94,7 @@ func nodePortSameInAllClusters(backend v1beta1.IngressBackend, namespace string,
 	return nil
 }
 
+// ServerVersionsNewEnough returns an error if the version of any cluster is not supported.
 func ServerVersionsNewEnough(clients map[string]kubeclient.Interface) error {
 	for key := range clients {
 		glog.Infof("Checking client %s", key)
@@ -109,7 +112,7 @@ func ServerVersionsNewEnough(clients map[string]kubeclient.Interface) error {
 			return err
 		}
 		if newEnough := serverVersionNewEnough(major, minor, patch); !newEnough {
-			return fmt.Errorf("Cluster %s (ver %d.%d.%d) is not running a supported kubernetes version. Need >= 1.8.1 and not 1.10.0.\n",
+			return fmt.Errorf("cluster %s (ver %d.%d.%d) is not running a supported kubernetes version. Need >= 1.8.1 and not 1.10.0",
 				key, major, minor, patch)
 		}
 

--- a/app/kubemci/pkg/validations/validations_test.go
+++ b/app/kubemci/pkg/validations/validations_test.go
@@ -17,12 +17,73 @@ package validations
 import (
 	"testing"
 
+	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/ingress"
 	"github.com/golang/glog"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	coretesting "k8s.io/client-go/testing"
 )
+
+func addServiceReactor(client *fake.Clientset, nodePort int64) {
+	client.AddReactor("get", "services", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+		glog.V(2).Infof("fake.Client.Get.Services.")
+		ret = &v1.Service{
+			Spec: v1.ServiceSpec{
+				Ports: []v1.ServicePort{
+					{
+						Port:     80,
+						NodePort: int32(nodePort),
+					},
+				},
+			},
+		}
+		return true, ret, nil
+	})
+}
+
+func TestServicesNodePortsSameFails(t *testing.T) {
+	ing := v1beta1.Ingress{}
+	if err := ingress.UnmarshallAndApplyDefaults("../../../../testdata/ingress.yaml", "" /*namespace*/, &ing); err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	client1 := &fake.Clientset{}
+	client2 := &fake.Clientset{}
+	addServiceReactor(client1, 31000)
+	addServiceReactor(client2, 31000)
+
+	clients := map[string]kubeclient.Interface{
+		"cluster1": client1,
+		"cluster2": client2,
+	}
+
+	// Test where validation passes.
+	err := servicesNodePortsSame(clients, &ing)
+	if err != nil {
+		t.Errorf("Validation should pass. Got err: %v", err)
+	}
+
+	// Test where validation fails
+	client3 := &fake.Clientset{}
+	addServiceReactor(client3, 31005)
+	clients = map[string]kubeclient.Interface{
+		"cluster2": client2,
+		"cluster3": client3,
+	}
+	err = servicesNodePortsSame(clients, &ing)
+	if err == nil {
+		t.Errorf("Validation should fail due to differing node ports. Got nil error")
+	} else {
+		glog.Infof("servicesNodePortSame err is %v", err)
+	}
+
+}
 
 func TestParseVersion(t *testing.T) {
 	var parseTests = []struct {
@@ -108,7 +169,6 @@ func TestVersionsAcrossClusters(t *testing.T) {
 	}
 
 	for _, tt := range versionTests {
-		glog.Infof("start")
 		clients := make(map[string]kubeclient.Interface)
 		clients["cluster1"] = fake.NewSimpleClientset()
 
@@ -123,7 +183,6 @@ func TestVersionsAcrossClusters(t *testing.T) {
 		fakeclientDiscovery.FakedServerVersion = &verInfo
 
 		err := ServerVersionsNewEnough(clients)
-		glog.Infof("err: %v", err)
 		if tt.isErr != (err != nil) {
 			t.Errorf("error testing version. Expected err? %v Err:%v", tt.isErr, err)
 		}

--- a/testdata/ingress.yaml
+++ b/testdata/ingress.yaml
@@ -11,3 +11,6 @@ spec:
         backend:
           serviceName: echoheadersx
           servicePort: 80
+  backend:
+    serviceName: echoheadersx
+    servicePort: 80


### PR DESCRIPTION
-Adds a default backend to testdata/ingress.yaml, needed to pass validation.
-Fixes a few lint errors in validations.go.

cc @nikhiljindal @csbell

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/179)
<!-- Reviewable:end -->
