### PR TITLE
Move all validation to create.go and add more unit testing.

### DIFF
--- a/app/kubemci/cmd/create.go
+++ b/app/kubemci/cmd/create.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/api/extensions/v1beta1"
+	kubeclient "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	// gcp is needed for GKE cluster auth to work.
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
@@ -149,8 +151,12 @@ func runCreate(options *createOptions, args []string) error {
 		return err
 	}
 
+	return createIngressAndLoadBalancer(ing, clients, options, cloudInterface, validations.NewValidator())
+}
+
+func createIngressAndLoadBalancer(ing v1beta1.Ingress, clients map[string]kubeclient.Interface, options *createOptions, cloudInterface *gce.GCECloud, validator validations.ValidatorInterface) error {
 	if options.Validate {
-		if err := validations.ServerVersionsNewEnough(clients); err != nil {
+		if err := validator.Validate(clients, &ing); err != nil {
 			return err
 		}
 	}

--- a/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
+++ b/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
@@ -47,7 +47,6 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/urlmap"
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/utils"
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/kubeutils"
-	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/validations"
 )
 
 const (
@@ -112,16 +111,6 @@ func (l *Syncer) CreateLoadBalancer(ing *v1beta1.Ingress, forceUpdate, validate 
 	if cErr != nil {
 		// No point in continuing without a client.
 		return cErr
-	}
-
-	if validate {
-		// TODO(G-Harmon): Move this earlier to create.go and consolidate with the other validation there.
-		if err := validations.Validate(l.clients, ing); err != nil {
-			return fmt.Errorf("validation failed: %s", err)
-		}
-		glog.Infof("Validation passed.")
-	} else {
-		fmt.Println("Validation skipped. (Set --validate to enable.)")
 	}
 
 	ports := l.ingToNodePorts(ing, client)

--- a/app/kubemci/pkg/validations/fake_validations.go
+++ b/app/kubemci/pkg/validations/fake_validations.go
@@ -1,0 +1,46 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"github.com/golang/glog"
+	"k8s.io/api/extensions/v1beta1"
+	kubeclient "k8s.io/client-go/kubernetes"
+)
+
+// FakeValidator is a fake implementation of ValidatorInterface, for tests.
+type FakeValidator struct {
+	ValidatedClusterSets []map[string]kubeclient.Interface
+}
+
+// NewFakeValidator returns a new intance of the fake Validator.
+func NewFakeValidator() ValidatorInterface {
+	return &FakeValidator{}
+}
+
+// Ensure this implements BackendServiceSyncerInterface.
+var _ ValidatorInterface = &FakeValidator{}
+
+// Validate records the clusters that were validated, so tests can use that information.
+func (v *FakeValidator) Validate(clients map[string]kubeclient.Interface, ing *v1beta1.Ingress) error {
+	return v.serverVersionsNewEnough(clients)
+	// TODO: Might be useful to also call serviceNodePortsSame.
+}
+
+func (v *FakeValidator) serverVersionsNewEnough(clients map[string]kubeclient.Interface) error {
+	glog.V(3).Infof("Fake ServerVersionsNewEnough: %v", clients)
+	v.ValidatedClusterSets = append(v.ValidatedClusterSets, clients)
+	return nil
+}

--- a/app/kubemci/pkg/validations/interfaces.go
+++ b/app/kubemci/pkg/validations/interfaces.go
@@ -1,0 +1,25 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"k8s.io/api/extensions/v1beta1"
+	kubeclient "k8s.io/client-go/kubernetes"
+)
+
+// ValidatorInterface is an interface to validate cluster setup.
+type ValidatorInterface interface {
+	Validate(clients map[string]kubeclient.Interface, ing *v1beta1.Ingress) error
+}

--- a/app/kubemci/pkg/validations/validations.go
+++ b/app/kubemci/pkg/validations/validations.go
@@ -27,8 +27,22 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 )
 
+// validator is a concrete implementation of ValidatorInterface.
+type validator struct {
+}
+
+var _ ValidatorInterface = &validator{}
+
+// NewValidator returns a new Validator.
+func NewValidator() ValidatorInterface {
+	return &validator{}
+}
+
 // Validate performs pre-flight checks on the clusters and services.
-func Validate(clients map[string]kubeclient.Interface, ing *v1beta1.Ingress) error {
+func (v *validator) Validate(clients map[string]kubeclient.Interface, ing *v1beta1.Ingress) error {
+	if err := serverVersionsNewEnough(clients); err != nil {
+		return err
+	}
 	return servicesNodePortsSame(clients, ing)
 }
 
@@ -94,8 +108,8 @@ func nodePortSameInAllClusters(backend v1beta1.IngressBackend, namespace string,
 	return nil
 }
 
-// ServerVersionsNewEnough returns an error if the version of any cluster is not supported.
-func ServerVersionsNewEnough(clients map[string]kubeclient.Interface) error {
+// serverVersionsNewEnough returns an error if the version of any cluster is not supported.
+func serverVersionsNewEnough(clients map[string]kubeclient.Interface) error {
 	for key := range clients {
 		glog.Infof("Checking client %s", key)
 		discoveryClient := clients[key].Discovery()

--- a/app/kubemci/pkg/validations/validations_test.go
+++ b/app/kubemci/pkg/validations/validations_test.go
@@ -47,7 +47,7 @@ func addServiceReactor(client *fake.Clientset, nodePort int64) {
 	})
 }
 
-func TestServicesNodePortsSameFails(t *testing.T) {
+func TestServicesNodePortsSame(t *testing.T) {
 	ing := v1beta1.Ingress{}
 	if err := ingress.UnmarshallAndApplyDefaults("../../../../testdata/ingress.yaml", "" /*namespace*/, &ing); err != nil {
 		t.Fatalf("%s", err)
@@ -182,7 +182,7 @@ func TestVersionsAcrossClusters(t *testing.T) {
 		verInfo.GitVersion = tt.version
 		fakeclientDiscovery.FakedServerVersion = &verInfo
 
-		err := ServerVersionsNewEnough(clients)
+		err := serverVersionsNewEnough(clients)
 		if tt.isErr != (err != nil) {
 			t.Errorf("error testing version. Expected err? %v Err:%v", tt.isErr, err)
 		}


### PR DESCRIPTION
-Creates an interface for Validations and a fake Validator for unit tests.
-Adds a unit test for create.go:createIngressAndLoadBalancer.

cc @nikhiljindal @csbell

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/183)
<!-- Reviewable:end -->
