### PR TITLE
Make gofmt check return an error, and check more .go files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ PKG=github.com/GoogleCloudPlatform/k8s-multicluster-ingress
 
 fmt:
 	@echo "+ $@"
-	@go list -f '{{if len .TestGoFiles}}"gofmt -s -d {{.Dir}}"{{end}}' $(shell go list ${PKG}/... | grep -v vendor) | xargs -L 1 sh -c
+	@./scripts/check-gofmt.sh
 
 lint:
 	@echo "+ $@"

--- a/scripts/check-gofmt.sh
+++ b/scripts/check-gofmt.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+set -o pipefail
+
+files=$(find . -name "*.go"| grep -v "/vendor/")
+diff=$(gofmt -s -d ${files})
+if [ -n "${diff}" ]; then
+  echo -e "gofmt failed:\n${diff}"
+  exit 1
+fi

--- a/test/e2e/cases/hcFromProbe.go
+++ b/test/e2e/cases/hcFromProbe.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	svcNodePort = 30061
+	svcNodePort    = 30061
 	expectedHcPath = "/healthz"
 )
 


### PR DESCRIPTION
In order for gofmt to be blocking, we have to wrap it in a script that checks
for a non-empty return.  In the process, I switched from using "go list"
[dirs with _test.go files] to using all .go files that aren't in /vendor.

cc @madhusudancs @nikhiljindal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/184)
<!-- Reviewable:end -->
