### PR TITLE
Adding go get golint before running go lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ fmt:
 
 lint:
 	@echo "+ $@"
+	@go get -u golang.org/x/lint/golint
 	@go list -f '{{if len .TestGoFiles}}"golint {{.Dir}}/..."{{end}}' $(shell go list ${PKG}/... | grep -v vendor) | xargs -L 1 sh -c
 
 vet:


### PR DESCRIPTION
Fixing https://github.com/kubernetes/test-infra/pull/7563#issuecomment-379324371 to ensure that we fetch golint before running it.

cc @G-Harmon @BenTheElder @krzyzacy