### PR TITLE
Make lint errors blocking, and fix a few last lint problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ fmt:
 lint:
 	@echo "+ $@"
 	@go get -u golang.org/x/lint/golint
-	@go list -f '{{if len .TestGoFiles}}"golint {{.Dir}}/..."{{end}}' $(shell go list ${PKG}/... | grep -v vendor) | xargs -L 1 sh -c
+	@./scripts/check-golint.sh
 
 vet:
 	@echo "+ $@"

--- a/app/kubemci/pkg/gcp/cloudinterface/interface.go
+++ b/app/kubemci/pkg/gcp/cloudinterface/interface.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 )
 
+// NewGCECloudInterface returns a new GCECloud.
 func NewGCECloudInterface(projectID string) (*gce.GCECloud, error) {
 	config := getCloudConfig(projectID)
 	return gce.CreateGCECloud(&config)

--- a/app/kubemci/pkg/gcp/forwardingrule/forwardingrulesyncer.go
+++ b/app/kubemci/pkg/gcp/forwardingrule/forwardingrulesyncer.go
@@ -61,15 +61,15 @@ var _ SyncerInterface = &Syncer{}
 // Does nothing if it exists already, else creates a new one.
 // See interface for more details.
 func (s *Syncer) EnsureHTTPForwardingRule(lbName, ipAddress, targetProxyLink string, forceUpdate bool) error {
-	s.namer.HttpForwardingRuleName()
-	return s.ensureForwardingRule(lbName, ipAddress, targetProxyLink, httpDefaultPortRange, "http", s.namer.HttpForwardingRuleName(), forceUpdate)
+	s.namer.HTTPForwardingRuleName()
+	return s.ensureForwardingRule(lbName, ipAddress, targetProxyLink, httpDefaultPortRange, "http", s.namer.HTTPForwardingRuleName(), forceUpdate)
 }
 
 // EnsureHTTPSForwardingRule ensures that the required https forwarding rule exists.
 // Does nothing if it exists already, else creates a new one.
 // See interface for more details.
 func (s *Syncer) EnsureHTTPSForwardingRule(lbName, ipAddress, targetProxyLink string, forceUpdate bool) error {
-	return s.ensureForwardingRule(lbName, ipAddress, targetProxyLink, httpsDefaultPortRange, "https", s.namer.HttpsForwardingRuleName(), forceUpdate)
+	return s.ensureForwardingRule(lbName, ipAddress, targetProxyLink, httpsDefaultPortRange, "https", s.namer.HTTPSForwardingRuleName(), forceUpdate)
 }
 
 // ensureForwardingRule ensures a forwarding rule exists as per the given input parameters.
@@ -107,7 +107,7 @@ func (s *Syncer) ensureForwardingRule(lbName, ipAddress, targetProxyLink, portRa
 // See interface for more details.
 func (s *Syncer) DeleteForwardingRules() error {
 	var err error
-	name := s.namer.HttpForwardingRuleName()
+	name := s.namer.HTTPForwardingRuleName()
 	fmt.Println("Deleting HTTP forwarding rule", name)
 	httpErr := s.frp.DeleteGlobalForwardingRule(name)
 	if httpErr != nil {
@@ -121,7 +121,7 @@ func (s *Syncer) DeleteForwardingRules() error {
 	} else {
 		fmt.Println("HTTP forwarding rule", name, "deleted successfully")
 	}
-	name = s.namer.HttpsForwardingRuleName()
+	name = s.namer.HTTPSForwardingRuleName()
 	fmt.Println("Deleting HTTPS forwarding rule", name)
 	httpsErr := s.frp.DeleteGlobalForwardingRule(name)
 	if httpsErr != nil {
@@ -142,14 +142,14 @@ func (s *Syncer) DeleteForwardingRules() error {
 // See interface for more details.
 func (s *Syncer) GetLoadBalancerStatus(lbName string) (*status.LoadBalancerStatus, error) {
 	// Fetch the http forwarding rule.
-	httpName := s.namer.HttpForwardingRuleName()
+	httpName := s.namer.HTTPForwardingRuleName()
 	httpFr, httpErr := s.frp.GetGlobalForwardingRule(httpName)
 	if httpErr == nil {
 		return getStatus(httpFr)
 	}
 	// Try fetching https forwarding rule.
 	// Ingresses with http-only annotation will not have a http forwarding rule.
-	httpsName := s.namer.HttpsForwardingRuleName()
+	httpsName := s.namer.HTTPSForwardingRuleName()
 	httpsFr, httpsErr := s.frp.GetGlobalForwardingRule(httpsName)
 	if httpsErr == nil {
 		return getStatus(httpsFr)
@@ -213,8 +213,8 @@ func (s *Syncer) ListLoadBalancerStatuses() ([]status.LoadBalancerStatus, error)
 // RemoveClustersFromStatus removes the given clusters from the forwarding rule.
 // See interface for more details.
 func (s *Syncer) RemoveClustersFromStatus(clusters []string) error {
-	httpsErr := s.removeClustersFromStatus("https", s.namer.HttpsForwardingRuleName(), clusters)
-	httpErr := s.removeClustersFromStatus("http", s.namer.HttpForwardingRuleName(), clusters)
+	httpsErr := s.removeClustersFromStatus("https", s.namer.HTTPSForwardingRuleName(), clusters)
+	httpErr := s.removeClustersFromStatus("http", s.namer.HTTPForwardingRuleName(), clusters)
 	// If both are not found, then return that.
 	if utils.IsHTTPErrorCode(httpErr, http.StatusNotFound) && utils.IsHTTPErrorCode(httpsErr, http.StatusNotFound) {
 		return httpErr

--- a/app/kubemci/pkg/gcp/forwardingrule/forwardingrulesyncer_test.go
+++ b/app/kubemci/pkg/gcp/forwardingrule/forwardingrulesyncer_test.go
@@ -32,7 +32,7 @@ import (
 func TestEnsureHTTPForwardingRule(t *testing.T) {
 	lbName := "lb-name"
 	namer := utilsnamer.NewNamer("mci1", lbName)
-	frName := namer.HttpForwardingRuleName()
+	frName := namer.HTTPForwardingRuleName()
 	frp := ingresslb.NewFakeLoadBalancers("" /*name*/, nil /*namer*/)
 	// GET should return NotFound.
 	if _, err := frp.GetGlobalForwardingRule(frName); err == nil {
@@ -116,7 +116,7 @@ func TestEnsureHTTPForwardingRule(t *testing.T) {
 func TestEnsureHTTPSForwardingRule(t *testing.T) {
 	lbName := "lb-name"
 	namer := utilsnamer.NewNamer("mci1", lbName)
-	frName := namer.HttpsForwardingRuleName()
+	frName := namer.HTTPSForwardingRuleName()
 	frp := ingresslb.NewFakeLoadBalancers("" /*name*/, nil /*namer*/)
 	// GET should return NotFound.
 	if _, err := frp.GetGlobalForwardingRule(frName); err == nil {
@@ -353,7 +353,7 @@ func TestListLoadBalancerStatuses(t *testing.T) {
 				}
 				if fr.hasStatus {
 					typedFRS := frs.(*Syncer)
-					name := typedFRS.namer.HttpsForwardingRuleName()
+					name := typedFRS.namer.HTTPSForwardingRuleName()
 					if err := addStatus(typedFRS, fr.lbName, name, ipAddr, clusters); err != nil {
 						t.Errorf("unexpected error in adding status to forwarding rule: %s. Moving to next test case", err)
 						continue
@@ -366,7 +366,7 @@ func TestListLoadBalancerStatuses(t *testing.T) {
 				}
 				if fr.hasStatus {
 					typedFRS := frs.(*Syncer)
-					name := typedFRS.namer.HttpForwardingRuleName()
+					name := typedFRS.namer.HTTPForwardingRuleName()
 					if err := addStatus(typedFRS, fr.lbName, name, ipAddr, clusters); err != nil {
 						t.Errorf("unexpected error in adding status to forwarding rule: %s. Moving to next test case", err)
 						continue
@@ -420,7 +420,7 @@ func TestListLoadBalancersWithSkippedRules(t *testing.T) {
 		t.Fatalf("expected no error in ensuring forwarding rule, actual: %v", err)
 	}
 	typedFRS := frs.(*Syncer)
-	name := typedFRS.namer.HttpForwardingRuleName()
+	name := typedFRS.namer.HTTPForwardingRuleName()
 	if err := addStatus(typedFRS, lbName, name, ipAddr, clusters); err != nil {
 		t.Fatalf("unexpected error in adding status: %s", err)
 	}
@@ -458,8 +458,8 @@ func TestDeleteForwardingRule(t *testing.T) {
 	tpLink := "fakeLink"
 	frp := ingresslb.NewFakeLoadBalancers("" /*name*/, nil /*namer*/)
 	namer := utilsnamer.NewNamer("mci1", lbName)
-	httpFrName := namer.HttpForwardingRuleName()
-	httpsFrName := namer.HttpsForwardingRuleName()
+	httpFrName := namer.HTTPForwardingRuleName()
+	httpsFrName := namer.HTTPSForwardingRuleName()
 	frs := NewForwardingRuleSyncer(namer, frp)
 	// Verify that trying to delete when no rule exists does not return any error.
 	if err := frs.DeleteForwardingRules(); err != nil {
@@ -518,7 +518,7 @@ func TestGetLoadBalancerStatus(t *testing.T) {
 
 	// Update the forwarding rule to have a status to simulate old forwarding rules that have the right status.
 	typedFRS := frs.(*Syncer)
-	name := typedFRS.namer.HttpForwardingRuleName()
+	name := typedFRS.namer.HTTPForwardingRuleName()
 	if err := addStatus(typedFRS, lbName, name, ipAddr, clusters); err != nil {
 		t.Fatalf("%s", err)
 	}
@@ -616,7 +616,7 @@ func TestRemoveClustersFromStatusWithStatus(t *testing.T) {
 			if err := frs.EnsureHTTPForwardingRule(lbName, ipAddr, tpLink, false /*force*/); err != nil {
 				t.Errorf("expected no error in ensuring http forwarding rule, actual: %v", err)
 			}
-			name := typedFRS.namer.HttpForwardingRuleName()
+			name := typedFRS.namer.HTTPForwardingRuleName()
 			// Add status to the forwarding rule to simulate old forwarding rule which has status.
 			if err := addStatus(typedFRS, lbName, name, ipAddr, clusters); err != nil {
 				t.Errorf("%s", err)
@@ -627,7 +627,7 @@ func TestRemoveClustersFromStatusWithStatus(t *testing.T) {
 			if err := frs.EnsureHTTPSForwardingRule(lbName, ipAddr, tpLink, false /*force*/); err != nil {
 				t.Errorf("expected no error in ensuring https forwarding rule, actual: %v", err)
 			}
-			name := typedFRS.namer.HttpsForwardingRuleName()
+			name := typedFRS.namer.HTTPSForwardingRuleName()
 			// Add status to the forwarding rule to simulate old forwarding rule which has status.
 			// TODO: This should not be required once lbc.RemoveFromClusters can update url map status:
 			// https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/pull/151
@@ -704,7 +704,7 @@ func TestRemoveClustersFromStatus(t *testing.T) {
 			}
 		}
 		if c.hasStatus {
-			name := typedFRS.namer.HttpForwardingRuleName()
+			name := typedFRS.namer.HTTPForwardingRuleName()
 			// Add status to the forwarding rule to simulate old forwarding rule which has status.
 			if err := addStatus(typedFRS, lbName, name, ipAddr, clusters); err != nil {
 				t.Errorf("%s", err)

--- a/app/kubemci/pkg/gcp/instances/fake_instancegetter.go
+++ b/app/kubemci/pkg/gcp/instances/fake_instancegetter.go
@@ -18,16 +18,17 @@ import (
 	compute "google.golang.org/api/compute/v1"
 )
 
-func newInstance(igUrl string) *compute.Instance {
+func newInstance(igURL string) *compute.Instance {
 	return &compute.Instance{
-		Name: igUrl,
-		Zone: igUrl,
+		Name: igURL,
+		Zone: igURL,
 		Tags: &compute.Tags{
-			Items: []string{igUrl},
+			Items: []string{igURL},
 		},
 	}
 }
 
+// NewFakeInstanceGetter returns a new fake.
 func NewFakeInstanceGetter() InstanceGetterInterface {
 	return &FakeInstanceGetter{}
 }
@@ -39,6 +40,7 @@ type FakeInstanceGetter struct {
 // Ensure this implements InstanceGetterInterface
 var _ InstanceGetterInterface = &FakeInstanceGetter{}
 
-func (g *FakeInstanceGetter) GetInstance(igUrl string) (*compute.Instance, error) {
-	return newInstance(igUrl), nil
+// GetInstance retuns a new instance.
+func (g *FakeInstanceGetter) GetInstance(igURL string) (*compute.Instance, error) {
+	return newInstance(igURL), nil
 }

--- a/app/kubemci/pkg/gcp/instances/instancegetter.go
+++ b/app/kubemci/pkg/gcp/instances/instancegetter.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/gcp/utils"
 )
 
+// NewInstanceGetter returns an InstanceGetter implementation.
 func NewInstanceGetter(projectID string) (InstanceGetterInterface, error) {
 	ctx := context.Background()
 	client, err := google.DefaultClient(ctx, compute.CloudPlatformScope)
@@ -37,6 +38,7 @@ func NewInstanceGetter(projectID string) (InstanceGetterInterface, error) {
 	}, nil
 }
 
+// InstanceGetter is an implementation of InstanceGetterInterface.
 type InstanceGetter struct {
 	gcpProjectID string
 	client       *http.Client
@@ -45,6 +47,7 @@ type InstanceGetter struct {
 // Ensure this implements InstanceGetterInterface
 var _ InstanceGetterInterface = &InstanceGetter{}
 
+// GetInstance gets an instance in the given instance group.
 func (g *InstanceGetter) GetInstance(igURL string) (*compute.Instance, error) {
 	service, err := compute.New(g.client)
 	if err != nil {

--- a/app/kubemci/pkg/gcp/instances/interfaces.go
+++ b/app/kubemci/pkg/gcp/instances/interfaces.go
@@ -11,18 +11,18 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
+
 package instances
 
 import (
 	compute "google.golang.org/api/compute/v1"
 )
 
-// Interface to fetch GCE instances.
+// InstanceGetterInterface is an interface to fetch GCE instances.
 // TODO(nikhiljindal): Move this logic to gce cloudprovider in kubernetes/kubernetes.
 type InstanceGetterInterface interface {
-	// Returns an instance in the given instance group.
+	// GetIntance returns an instance in the given instance group.
 	// There is no guarantee regarding which instance is returned.
 	// Calling this multiple times for the same instance group can return different instances.
-	GetInstance(igUrl string) (*compute.Instance, error)
+	GetInstance(igURL string) (*compute.Instance, error)
 }

--- a/app/kubemci/pkg/gcp/namer/namer.go
+++ b/app/kubemci/pkg/gcp/namer/namer.go
@@ -22,8 +22,8 @@ const (
 	hcPrefix                  = "hc"
 	backendPrefix             = "be"
 	urlMapPrefix              = "um"
-	targetHttpProxyPrefix     = "tp"
-	targetHttpsProxyPrefix    = "tps"
+	targetHTTPProxyPrefix     = "tp"
+	targetHTTPSProxyPrefix    = "tps"
 	httpForwardingRulePrefix  = "fw"
 	httpsForwardingRulePrefix = "fws"
 	firewallRulePrefix        = "fr"
@@ -42,11 +42,13 @@ const (
 	nameLenLimit = 62
 )
 
+// Namer provides a naming schema for GCP resources
 type Namer struct {
 	prefix string
 	lbName string
 }
 
+// NewNamer returns a new namer using the given prefix and load balancer name.
 func NewNamer(prefix, lbName string) *Namer {
 	return &Namer{
 		prefix: prefix,
@@ -54,45 +56,54 @@ func NewNamer(prefix, lbName string) *Namer {
 	}
 }
 
+// HealthCheckName returns the name for a health check on the given port.
 func (n *Namer) HealthCheckName(port int64) string {
 	return n.decorateName(fmt.Sprintf("%v-%v-%d", n.prefix, hcPrefix, port))
 }
 
+// BeServiceName returns the name for the backend service on the given port.
 func (n *Namer) BeServiceName(port int64) string {
 	// We append the load balancer name to the backend service name and
-	// hence we dont share a backend service even if same kube service is
+	// hence we don't share a backend service even if same kube service is
 	// backing multiple load balancers across the same set of clusters.
 	// This is different than single cluster ingress, where we reuse backend services.
-	// This is difficult in multi cluster ingres since we will need to keep track
+	// This is difficult in multi-cluster ingress since we will need to keep track
 	// of the set of clusters the load balancer is spread to and stop/start sharing
 	// anytime that set changes.
 	return n.decorateName(fmt.Sprintf("%v-%v-%d", n.prefix, backendPrefix, port))
 }
 
+// URLMapName returns the name for a url map.
 func (n *Namer) URLMapName() string {
 	return n.decorateName(fmt.Sprintf("%v-%v", n.prefix, urlMapPrefix))
 }
 
-func (n *Namer) TargetHttpProxyName() string {
-	return n.decorateName(fmt.Sprintf("%v-%v", n.prefix, targetHttpProxyPrefix))
+// TargetHTTPProxyName returns a name for the http proxy.
+func (n *Namer) TargetHTTPProxyName() string {
+	return n.decorateName(fmt.Sprintf("%v-%v", n.prefix, targetHTTPProxyPrefix))
 }
 
-func (n *Namer) TargetHttpsProxyName() string {
-	return n.decorateName(fmt.Sprintf("%v-%v", n.prefix, targetHttpsProxyPrefix))
+// TargetHTTPSProxyName returns a name for the https proxy.
+func (n *Namer) TargetHTTPSProxyName() string {
+	return n.decorateName(fmt.Sprintf("%v-%v", n.prefix, targetHTTPSProxyPrefix))
 }
 
-func (n *Namer) HttpsForwardingRuleName() string {
+// HTTPSForwardingRuleName returns the forwarding rule name.
+func (n *Namer) HTTPSForwardingRuleName() string {
 	return n.decorateName(fmt.Sprintf("%v-%v", n.prefix, httpsForwardingRulePrefix))
 }
 
-func (n *Namer) HttpForwardingRuleName() string {
+// HTTPForwardingRuleName returns the forwarding rule name.
+func (n *Namer) HTTPForwardingRuleName() string {
 	return n.decorateName(fmt.Sprintf("%v-%v", n.prefix, httpForwardingRulePrefix))
 }
 
+// FirewallRuleName returns a name for a firewall.
 func (n *Namer) FirewallRuleName() string {
 	return n.decorateName(fmt.Sprintf("%v-%v", n.prefix, firewallRulePrefix))
 }
 
+// SSLCertName returns a name for SSL certificates.
 func (n *Namer) SSLCertName() string {
 	return n.decorateName(fmt.Sprintf("%v-%v", n.prefix, sslCertPrefix))
 }

--- a/app/kubemci/pkg/gcp/status/loadbalancerstatus.go
+++ b/app/kubemci/pkg/gcp/status/loadbalancerstatus.go
@@ -7,7 +7,7 @@ import (
 	"github.com/golang/glog"
 )
 
-// Struct to describe a multi cluster load balancer.
+// LoadBalancerStatus describes a multi-cluster load balancer.
 type LoadBalancerStatus struct {
 	// Human readable description for this status.
 	// If we are using the description field of a GCP resource to store this status,
@@ -22,6 +22,7 @@ type LoadBalancerStatus struct {
 	// TODO: Store errors that were generated during creating and deleting this load balancer.
 }
 
+// ToString converts a LoadBalancerStatus to a string.
 func (s LoadBalancerStatus) ToString() (string, error) {
 	jsonValue, err := json.Marshal(s)
 	if err != nil {
@@ -30,6 +31,7 @@ func (s LoadBalancerStatus) ToString() (string, error) {
 	return string(jsonValue), nil
 }
 
+// FromString reads in a string param and converts it to a LoadBalancerStatus.
 func FromString(str string) (*LoadBalancerStatus, error) {
 	var s LoadBalancerStatus
 	if err := json.Unmarshal([]byte(str), &s); err != nil {

--- a/app/kubemci/pkg/gcp/targetproxy/targetproxysyncer.go
+++ b/app/kubemci/pkg/gcp/targetproxy/targetproxysyncer.go
@@ -78,7 +78,7 @@ func (s *Syncer) EnsureHTTPSTargetProxy(lbName, umLink, certLink string, forceUp
 // See interface comments for details.
 func (s *Syncer) DeleteTargetProxies() error {
 	var err error
-	httpName := s.namer.TargetHttpProxyName()
+	httpName := s.namer.TargetHTTPProxyName()
 	fmt.Println("Deleting target HTTP proxy", httpName)
 	httpErr := s.tpp.DeleteTargetHttpProxy(httpName)
 	if httpErr != nil {
@@ -93,7 +93,7 @@ func (s *Syncer) DeleteTargetProxies() error {
 		fmt.Println("Target HTTP proxy", httpName, "deleted successfully")
 	}
 
-	httpsName := s.namer.TargetHttpsProxyName()
+	httpsName := s.namer.TargetHTTPSProxyName()
 	fmt.Println("Deleting target HTTPS proxy", httpsName)
 	httpsErr := s.tpp.DeleteTargetHttpsProxy(httpsName)
 	if httpsErr != nil {
@@ -202,7 +202,7 @@ func targetHTTPProxyMatches(desiredHTTPProxy, existingHTTPProxy compute.TargetHt
 func (s *Syncer) desiredHTTPTargetProxy(lbName, umLink string) *compute.TargetHttpProxy {
 	// Compute the desired target http proxy.
 	return &compute.TargetHttpProxy{
-		Name:        s.namer.TargetHttpProxyName(),
+		Name:        s.namer.TargetHTTPProxyName(),
 		Description: fmt.Sprintf("Target http proxy for kubernetes multicluster loadbalancer %s", lbName),
 		UrlMap:      umLink,
 	}
@@ -295,7 +295,7 @@ func targetHTTPSProxyMatches(desiredHTTPSProxy, existingHTTPSProxy compute.Targe
 func (s *Syncer) desiredHTTPSTargetProxy(lbName, umLink, certLink string) *compute.TargetHttpsProxy {
 	// Compute the desired target https proxy.
 	return &compute.TargetHttpsProxy{
-		Name:            s.namer.TargetHttpsProxyName(),
+		Name:            s.namer.TargetHTTPSProxyName(),
 		Description:     fmt.Sprintf("Target https proxy for kubernetes multicluster loadbalancer %s", lbName),
 		UrlMap:          umLink,
 		SslCertificates: []string{certLink},

--- a/app/kubemci/pkg/gcp/targetproxy/targetproxysyncer_test.go
+++ b/app/kubemci/pkg/gcp/targetproxy/targetproxysyncer_test.go
@@ -28,7 +28,7 @@ func TestEnsureTargetHttpProxy(t *testing.T) {
 	// Should create the target proxy as expected.
 	tpp := ingresslb.NewFakeLoadBalancers("" /*name*/, nil /*namer*/)
 	namer := utilsnamer.NewNamer("mci1", lbName)
-	tpName := namer.TargetHttpProxyName()
+	tpName := namer.TargetHTTPProxyName()
 	tps := NewTargetProxySyncer(namer, tpp)
 	// GET should return NotFound.
 	if _, err := tpp.GetTargetHttpProxy(tpName); err == nil {
@@ -97,7 +97,7 @@ func TestEnsureTargetHttpsProxy(t *testing.T) {
 	// Should create the target proxy as expected.
 	tpp := ingresslb.NewFakeLoadBalancers("" /*name*/, nil /*namer*/)
 	namer := utilsnamer.NewNamer("mci1", lbName)
-	tpName := namer.TargetHttpsProxyName()
+	tpName := namer.TargetHTTPSProxyName()
 	tps := NewTargetProxySyncer(namer, tpp)
 	// GET should return NotFound.
 	if _, err := tpp.GetTargetHttpProxy(tpName); err == nil {
@@ -175,8 +175,8 @@ func TestDeleteTargetProxies(t *testing.T) {
 	certLink := "certSelfLink"
 	tpp := ingresslb.NewFakeLoadBalancers("" /*name*/, nil /*namer*/)
 	namer := utilsnamer.NewNamer("mci1", lbName)
-	httpTpName := namer.TargetHttpProxyName()
-	httpsTpName := namer.TargetHttpsProxyName()
+	httpTpName := namer.TargetHTTPProxyName()
+	httpsTpName := namer.TargetHTTPSProxyName()
 	tps := NewTargetProxySyncer(namer, tpp)
 	// Verify that trying to delete when no proxy exists does not return any error.
 	if err := tps.DeleteTargetProxies(); err != nil {

--- a/cmd/kubemci/app/kubemci.go
+++ b/cmd/kubemci/app/kubemci.go
@@ -20,6 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/cmd"
 )
 
+// Run runs the whole kubemci command.
 func Run() error {
 	kubemci := cmd.NewCommand(os.Stdin, os.Stdout, os.Stderr)
 	return kubemci.Execute()

--- a/scripts/check-golint.sh
+++ b/scripts/check-golint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+set -o pipefail
+
+diff=$(find . -name "*.go"| grep -v "/vendor/" | xargs -L 1 golint)
+if [ -n "${diff}" ]; then
+  echo -e "golint failed:\n${diff}"
+  exit 1
+fi

--- a/test/e2e/cases/basic.go
+++ b/test/e2e/cases/basic.go
@@ -21,10 +21,11 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-multicluster-ingress/app/kubemci/pkg/kubeutils"
 	"github.com/golang/glog"
 	kubeclient "k8s.io/client-go/kubernetes"
+	// Needed for authenticating gcp clusters
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
-// Creates a basic multicluster ingress and verifies that it works as expected.
+// RunBasicCreateTest creates a basic multicluster ingress and verifies that it works as expected.
 // TODO(nikhiljindal): Use ginkgo and gomega and possibly reuse k/k e2e framework.
 func RunBasicCreateTest() {
 	project, kubeConfigPath, lbName, ipName, clients := initDeps()
@@ -63,7 +64,7 @@ func testHTTPIngress(project, kubeConfigPath, lbName string) {
 	defer deleteFn()
 
 	// Tests
-	ipAddress := getIpAddress(project, lbName)
+	ipAddress := getIPAddress(project, lbName)
 	// Ensure that the IP address eventually returns 202.
 	if err := waitForIngress("http", ipAddress, "/"); err != nil {
 		glog.Errorf("error in waiting for ingress: %s", err)
@@ -95,7 +96,7 @@ func testHTTPSIngress(project, kubeConfigPath, lbName string, kubectlArgs []stri
 	defer deleteFn()
 
 	// Tests
-	ipAddress := getIpAddress(project, lbName)
+	ipAddress := getIPAddress(project, lbName)
 	// Ensure that the IP address eventually returns 202.
 	if err := waitForIngress("http", ipAddress, "/"); err != nil {
 		glog.Errorf("error in GET %s: %s", ipAddress, err)

--- a/test/e2e/cases/hcFromProbe.go
+++ b/test/e2e/cases/hcFromProbe.go
@@ -16,6 +16,7 @@ const (
 	expectedHcPath = "/healthz"
 )
 
+// RunHCFromProbeTest tests health checks.
 func RunHCFromProbeTest() {
 	project, kubeConfigPath, lbName, ipName, clients := initDeps()
 	kubectlArgs := []string{"kubectl", fmt.Sprintf("--kubeconfig=%s", kubeConfigPath)}
@@ -47,7 +48,7 @@ func testHCFromProbe(project, kubeConfigPath, lbName string) {
 	defer deleteFn()
 
 	// Tests
-	ipAddress := getIpAddress(project, lbName)
+	ipAddress := getIPAddress(project, lbName)
 	// Ensure that the IP address eventually returns 200 (on health check path, since the service used returns 404 on /)
 	if err := waitForIngress("http", ipAddress, expectedHcPath); err != nil {
 		glog.Errorf("error in waiting for ingress: %s", err)

--- a/test/e2e/cases/utils.go
+++ b/test/e2e/cases/utils.go
@@ -32,10 +32,14 @@ import (
 )
 
 const (
+	// Letters is the letters of the alphabet.
 	Letters = "abcdefghijklmnopqrstuvwxyz"
 
-	// On average it takes ~6 minutes for a single backend to come online in GCE.
-	LoadBalancerPollTimeout  = 12 * time.Minute
+	// LoadBalancerPollTimeout is how long we wait for a the LB to be
+	// ready. On average it takes ~6 minutes for a single backend to come
+	// online in GCE.
+	LoadBalancerPollTimeout = 12 * time.Minute
+	// LoadBalancerPollInterval is the time between checking for the LB to be ready.
 	LoadBalancerPollInterval = 10 * time.Second
 
 	// IngressReqTimeout is the timeout on a single http request.
@@ -112,8 +116,8 @@ func createTLSSecrets(kubectlArgs []string, clients map[string]kubeclient.Interf
 	return deleteFn
 }
 
-// getIpAddress gets the allocated IP address from a loadbalancer
-func getIpAddress(project, lbName string) string {
+// getIPAddress gets the allocated IP address from a loadbalancer
+func getIPAddress(project, lbName string) string {
 	// TODO(nikhiljindal): Figure out why is sleep required? get-status should work immediately after create is successful.
 	time.Sleep(5 * time.Second)
 	// Ensure that get-status returns the expected output.
@@ -158,7 +162,7 @@ func pollURL(route, host string, timeout time.Duration, interval time.Duration, 
 		return !expectUnreachable, nil
 	})
 	if pollErr != nil {
-		return fmt.Errorf("Failed to execute a successful GET within %v, Last response body for %v, host %v:\n%v\n\n%v\n",
+		return fmt.Errorf("failed to execute a successful GET within %v, Last response body for %v, host %v:\n%v\n\n%v",
 			timeout, route, host, lastBody, pollErr)
 	}
 	return nil


### PR DESCRIPTION
This adds a wrapper script to error-out if there are lint problems.
This only checks packages with _test.go files. We could extend it to all .go files in the code base (but there are a few more lint errors to fix).

Another commit fixes up 2 existing lint errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/186)
<!-- Reviewable:end -->
