### PR TITLE
Removing go get golint since the test image now has golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ fmt:
 
 lint:
 	@echo "+ $@"
-	@go get -u golang.org/x/lint/golint
 	@go list -f '{{if len .TestGoFiles}}"golint {{.Dir}}/..."{{end}}' $(shell go list ${PKG}/... | grep -v vendor) | xargs -L 1 sh -c
 
 vet:


### PR DESCRIPTION
Ref https://github.com/kubernetes/test-infra/pull/7604

cc @G-Harmon 