### PR TITLE
Delete ingress from cluster when updating GCP resources failed only if force=true

### DIFF
--- a/app/kubemci/cmd/remove_clusters.go
+++ b/app/kubemci/cmd/remove_clusters.go
@@ -142,6 +142,10 @@ func runRemoveClusters(options *removeClustersOptions, args []string) error {
 		return err
 	}
 	if delErr := lbs.RemoveFromClusters(&ing, clients, options.ForceUpdate); delErr != nil {
+		if !options.ForceUpdate {
+			return delErr
+		}
+		fmt.Printf("%s. Continuing with force remove\n", delErr)
 		err = multierror.Append(err, delErr)
 	}
 


### PR DESCRIPTION
Making remove-clusters code consistent with delete code.
If updating GCP resources failed, then return an error right away rather than continuing. Continue only if --force=true.

This also fixes our failing e2e test which is failing with leaking instance group which is the same issue as the one we had for delete: https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/pull/169.
If we delete the ingress from cluster before GCP resources (in particular the backend service) is deleted, then the ingress controller does not delete the instance group.
This fixes that.

cc @G-Harmon 