### PR TITLE
Documentation - Link & Instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ kubemci is a tool to configure Kubernetes ingress to load balance traffic across
 multiple Kubernetes clusters.
 
 This is a Google Cloud Platform [beta](https://cloud.google.com/terms/launch-stages) tool, suitable for limited production use cases:
-https://cloud.google.com/kubernetes-engine/docs/how-to/setup-multi-cluster-ingress
+https://cloud.google.com/kubernetes-engine/docs/how-to/kubemci
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ kubemci is a tool to configure Kubernetes ingress to load balance traffic across
 multiple Kubernetes clusters.
 
 This is a Google Cloud Platform [beta](https://cloud.google.com/terms/launch-stages) tool, suitable for limited production use cases:
-https://cloud.google.com/kubernetes-engine/docs/how-to/kubemci
+https://cloud.google.com/kubernetes-engine/docs/how-to/setup-multi-cluster-ingress
 
 ## Getting started
 

--- a/examples/zone-printer/README.md
+++ b/examples/zone-printer/README.md
@@ -56,6 +56,22 @@ used by `kubemci` to provision the multi-cluster Ingress.
     gcloud components install kubectl
     ```
 
+4. Install **`kubemci`**:
+
+    You can install `kubemci` by running:
+
+    ```shell
+    wget https://storage.googleapis.com/kubemci-release/release/latest/bin/linux/amd64/kubemci
+    chmod +x ./kubemci
+   
+    ```
+
+    In google cloud shell you can move this to your local bin to automatically include it in your path
+
+    ```shell
+    mv ./kubemci ~/bin/kubemci
+    ```
+
 ## 1. Create Kubernetes Clusters
 
 `kubemci` requires Kubernetes clusters that are v1.8.1 or newer. (You can check

--- a/examples/zone-printer/README.md
+++ b/examples/zone-printer/README.md
@@ -58,12 +58,24 @@ used by `kubemci` to provision the multi-cluster Ingress.
 
 4. Install **`kubemci`**:
 
-    You can install `kubemci` by running:
+    [kubemci](https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress) is the primary command-line tool used to create and configure a multi-cluster ingress.
+
+    Download one of the binaries and place it in an executable path:
+
+    - [Linux](https://storage.googleapis.com/kubemci-release/release/latest/bin/linux/amd64/kubemci)
+    - [macOS](https://storage.googleapis.com/kubemci-release/release/latest/bin/darwin/amd64/kubemci)
+
+    
+    For example on linux you can install `kubemci` by running:
 
     ```shell
     wget https://storage.googleapis.com/kubemci-release/release/latest/bin/linux/amd64/kubemci
+    ```
+
+    Ensure that the binary is executable. This can be done in the directory of the binary with the following command:
+
+    ```shell
     chmod +x ./kubemci
-   
     ```
 
     In google cloud shell you can move this to your local bin to automatically include it in your path


### PR DESCRIPTION
Updated a link on the main readme to point back to the correct link (https://cloud.google.com/kubernetes-engine/docs/how-to/kubemci)
Added instructions for installing kubemci itself in the example readme.