### PR TITLE
Address Coveralls Reported Coverage Level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Ignore GOBIN where we install go tools such as golint.
 /_output
+*.coverprofile

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,9 @@ coveralls:
 	@echo "+ $@"
 # Make sure goveralls is installed.
 	@go get github.com/mattn/goveralls
-	@CI_NAME="prow" CI_BUILD_NUMBER=${BUILD_ID} CI_BRANCH=${PULL_BASE_REF} CI_PULL_REQUEST=${PULL_NUMBER} goveralls -repotoken $(shell cat /etc/coveralls-token/coveralls.txt)
+	@CI_NAME="prow" CI_BUILD_NUMBER=${BUILD_ID} CI_BRANCH=${PULL_BASE_REF} CI_PULL_REQUEST=${PULL_NUMBER} goveralls \
+		-repotoken $(shell cat /etc/coveralls-token/coveralls.txt) \
+		-service="prow"
 
 build:
 	go build -a -installsuffix cgo ${GOPATH}/src/${PKG}/cmd/kubemci/kubemci.go

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 
 
 PKG=github.com/GoogleCloudPlatform/k8s-multicluster-ingress
+COVERPROFILE=combined.coverprofile
 
 # So that make test is not confused with the test directory.
 .PHONY: test
@@ -42,11 +43,18 @@ cover:
 
 coveralls:
 	@echo "+ $@"
+# Generate coverage report
+	@go test \
+		-coverprofile=${COVERPROFILE} \
+		-coverpkg=$(shell go list ${PKG}/... | xargs | sed -e 's/ /,/g') \
+		${PKG}/...
 # Make sure goveralls is installed.
 	@go get github.com/mattn/goveralls
+# Send coverage report to Goveralls
 	@CI_NAME="prow" CI_BUILD_NUMBER=${BUILD_ID} CI_BRANCH=${PULL_BASE_REF} CI_PULL_REQUEST=${PULL_NUMBER} goveralls \
 		-repotoken $(shell cat /etc/coveralls-token/coveralls.txt) \
-		-service="prow"
+		-service="prow" \
+		-coverprofile=${COVERPROFILE}
 
 build:
 	go build -a -installsuffix cgo ${GOPATH}/src/${PKG}/cmd/kubemci/kubemci.go

--- a/Makefile
+++ b/Makefile
@@ -39,15 +39,14 @@ test-all: fmt lint vet test
 
 cover:
 	@echo "+ $@"
-	@go list -f '{{if len .TestGoFiles}}"go test -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"{{end}}' $(shell go list ${PKG}/... | grep -v vendor) | xargs -L 1 sh -c
-
-coveralls:
-	@echo "+ $@"
-# Generate coverage report
 	@go test \
 		-coverprofile=${COVERPROFILE} \
 		-coverpkg=$(shell go list ${PKG}/... | xargs | sed -e 's/ /,/g') \
 		${PKG}/...
+
+coveralls:
+	@echo "+ $@"
+	@make cover
 # Make sure goveralls is installed.
 	@go get github.com/mattn/goveralls
 # Send coverage report to Goveralls


### PR DESCRIPTION
## Description
This PR addresses Issue https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/190

My guess is that the way Goveralls [merges profiles](https://github.com/mattn/goveralls/blob/e68c968003c2db2ad7cdf07b3c012c5ab12248a7/gocover.go#L32-L34) may have been affected by one of the Go releases. 

This PR uses the functionality of [Go 1.10](https://golang.org/doc/go1.10#test) to create the coverprofile. 
>The go test -coverpkg flag now interprets its argument as a comma-separated list of patterns to match against the dependencies of each test, not as a list of packages to load anew.

There are some existing issues open with how `coverpkg` works which may change the behavior of `go test` coverage reports in the future:
- https://github.com/golang/go/issues/23910
- https://github.com/golang/go/issues/23883

## Screenshots
Coverage prior to this PR:
<img width="715" alt="screen shot 2018-08-04 at 8 29 29 am" src="https://user-images.githubusercontent.com/10553761/43676992-89d9db4c-97c0-11e8-9749-0c8616d7876b.png">
https://coveralls.io/builds/18322614

Coverage with this PR:
<img width="717" alt="screen shot 2018-08-04 at 8 31 18 am" src="https://user-images.githubusercontent.com/10553761/43677010-ce583b2e-97c0-11e8-9d20-a4e8fc8b2a43.png">
https://coveralls.io/builds/18325241