### PR TITLE
Fix Coveralls invocation, by adding '-service "prow"' 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ coveralls:
 	@echo "+ $@"
 # Make sure goveralls is installed.
 	@go get github.com/mattn/goveralls
-	@CI_NAME="prow" CI_BUILD_NUMBER=${BUILD_ID} CI_BRANCH=${PULL_BASE_REF} CI_PULL_REQUEST=${PULL_NUMBER} goveralls -repotoken $(shell cat /etc/coveralls-token/coveralls.txt)
+	@CI_NAME="prow" CI_BUILD_NUMBER=${BUILD_ID} CI_BRANCH=${PULL_BASE_REF} CI_PULL_REQUEST=${PULL_NUMBER} goveralls -repotoken $(shell cat /etc/coveralls-token/coveralls.txt) -service "prow"
 
 build:
 	go build -a -installsuffix cgo ${GOPATH}/src/${PKG}/cmd/kubemci/kubemci.go


### PR DESCRIPTION
It has been failing with:
W0803 19:24:01.716] Bad response status from coveralls: 422
W0803 19:24:01.716] {"message":"Couldn't find a repository matching this job.","error":true}
W0803 19:24:01.718] make: *** [coveralls] Error 1
W0803 19:24:01.719] Traceback (most recent call last):
W0803 19:24:01.719]   File "/workspace/./test-infra/jenkins/../scenarios/execute.py", line 50, in <module>
W0803 19:24:01.719]     main(ARGS.env, ARGS.cmd + ARGS.args)
W0803 19:24:01.719]   File "/workspace/./test-infra/jenkins/../scenarios/execute.py", line 41, in main
W0803 19:24:01.719]     check(*cmd)
W0803 19:24:01.719]   File "/workspace/./test-infra/jenkins/../scenarios/execute.py", line 30, in check
W0803 19:24:01.720]     subprocess.check_call(cmd)
W0803 19:24:01.720]   File "/usr/lib/python2.7/subprocess.py", line 540, in check_call
W0803 19:24:01.747]     raise CalledProcessError(retcode, cmd)
W0803 19:24:01.747] subprocess.CalledProcessError: Command '('make', '-j', '5', 'test', 'coveralls', 'vet', 'fmt', 'lint')' returned non-zero exit status 2
I0803 19:24:01.752] Makefile:44: recipe for target 'coveralls' failed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/k8s-multicluster-ingress/201)
<!-- Reviewable:end -->
