### PR TITLE
update zone-printer https doc about blocking http traffic

### DIFF
--- a/examples/zone-printer/https.md
+++ b/examples/zone-printer/https.md
@@ -47,8 +47,8 @@ for more details.
 
 ## Blocking HTTP
 
-While a single cluster ingress also supports blocking HTTP traffic all together,
-kubemci does not support it yet.
+Users can block HTTP traffic by adding an annotation to their Ingress resource.
 
-https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/142 is
-the feature request issue tracking this.
+Refer to documentation
+[here](https://github.com/kubernetes/ingress-gce/blob/master/README.md#blocking-http)
+for more details.


### PR DESCRIPTION
Blocking HTTP traffic seems to be supported now (https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/142) and works for me in my testing. Just updating the doc to reflect this.