### PR TITLE
Fixing build failure due to missing formatting directives

### DIFF
--- a/app/kubemci/pkg/validations/validations.go
+++ b/app/kubemci/pkg/validations/validations.go
@@ -183,6 +183,6 @@ func parseVersion(version string) (uint64, uint64, uint64, error) {
 	if err != nil {
 		return 0, 0, 0, err
 	}
-	glog.V(2).Infof("Got version: major:", major, "minor:", minor, "patch:", patch)
+	glog.V(2).Infof("Got version: major: %s, minor: %s, patch: %s\n", major, minor, patch)
 	return major, minor, patch, nil
 }

--- a/app/kubemci/pkg/validations/validations.go
+++ b/app/kubemci/pkg/validations/validations.go
@@ -183,6 +183,6 @@ func parseVersion(version string) (uint64, uint64, uint64, error) {
 	if err != nil {
 		return 0, 0, 0, err
 	}
-	glog.V(2).Infof("Got version: major: %s, minor: %s, patch: %s\n", major, minor, patch)
+	glog.V(2).Infof("Got version: major: %d, minor: %d, patch: %d\n", major, minor, patch)
 	return major, minor, patch, nil
 }


### PR DESCRIPTION
Fixing build failure due to missing formatting directive in glog.Infof call.
The relevant error is as follows:
```
app/kubemci/pkg/validations/validations.go:186: Verbose.Infof call has arguments but no formatting directives
```
Example run with the failure: https://gubernator.k8s.io/build/kubernetes-jenkins/pr-logs/pull/GoogleCloudPlatform_k8s-multicluster-ingress/199/pull-kubernetes-multicluster-ingress-test/278/

cc @G-Harmon 