### PR TITLE
Networks

### DIFF
--- a/app/kubemci/pkg/gcp/firewallrule/firewallrulesyncer.go
+++ b/app/kubemci/pkg/gcp/firewallrule/firewallrulesyncer.go
@@ -93,8 +93,9 @@ func (s *Syncer) EnsureFirewallRule(lbName string, ports []ingressbe.ServicePort
 // DeleteFirewallRules deletes the firewall rules that EnsureFirewallRule would have created.
 // See the interface for more details.
 func (s *Syncer) DeleteFirewallRules() error {
-	name := s.namer.FirewallRuleName()
-	fmt.Println("Deleting firewall rule", name)
+	// TODO Herman: we do not know the name of the networks used. We should list ALL of the rules, but that is not exposed by kubernetes/ingress-gce
+	name := s.namer.FirewallRuleName("*")
+	fmt.Println("Deleting firewall rules", s.namer.FirewallRuleName("*"))
 	err := s.fwp.DeleteFirewall(name)
 	if err != nil {
 		if utils.IsHTTPErrorCode(err, http.StatusNotFound) {

--- a/app/kubemci/pkg/gcp/firewallrule/firewallrulesyncer.go
+++ b/app/kubemci/pkg/gcp/firewallrule/firewallrulesyncer.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/golang/glog"
 	compute "google.golang.org/api/compute/v1"
@@ -251,8 +252,9 @@ func (s *Syncer) desiredFirewallRule(lbName string, ports []ingressbe.ServicePor
 	sort.Strings(targetTags)
 
 	network := s.getNetworkName(instances[0])
+	networkIDPart := network[strings.LastIndex(network, "/")+1:]
 	return &compute.Firewall{
-		Name:         s.namer.FirewallRuleName(network),
+		Name:         s.namer.FirewallRuleName(networkIDPart),
 		Description:  fmt.Sprintf("Firewall rule for kubernetes multicluster loadbalancer %s", lbName),
 		SourceRanges: l7SrcRanges,
 		Allowed: []*compute.FirewallAllowed{

--- a/app/kubemci/pkg/gcp/namer/namer.go
+++ b/app/kubemci/pkg/gcp/namer/namer.go
@@ -99,8 +99,8 @@ func (n *Namer) HTTPForwardingRuleName() string {
 }
 
 // FirewallRuleName returns a name for a firewall.
-func (n *Namer) FirewallRuleName() string {
-	return n.decorateName(fmt.Sprintf("%v-%v", n.prefix, firewallRulePrefix))
+func (n *Namer) FirewallRuleName(network string) string {
+	return n.decorateName(fmt.Sprintf("%v-%v-%v", n.prefix, firewallRulePrefix, network))
 }
 
 // SSLCertName returns a name for SSL certificates.


### PR DESCRIPTION
Support having clusters with different networks.

## Discussion needed
Note that this breaks the functionality for deleting the ingress & is a breaking change (the fw name changes so it doesn't match fw rules created by previous kubemci versions anymore).

I saw a lot of TODOs in the code regarding networks, so I figured you have thought about the same problems as I encountered. Namely that the naming is problematic: once you have more than a single fw rule, you can not know which firewall rules exist, so then deleting them becomes a much harder problem. I noticed that this is made even worse by the fact that kubernetes/ingress-gce lacks the method to list firewall rules.