### PR TITLE
Support multiple pre-shared-certs.

### DIFF
--- a/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
+++ b/app/kubemci/pkg/gcp/loadbalancer/loadbalancersyncer.go
@@ -185,15 +185,14 @@ func (l *Syncer) CreateLoadBalancer(ing *v1beta1.Ingress, forceUpdate, validate 
 	if (ingAnnotations.UseNamedTLS() != "") || len(ing.Spec.TLS) > 0 {
 		// Note that we expect to load the cert from any cluster,
 		// so users are required to create the secret in all clusters.
-		certLink, cErr := l.scs.EnsureSSLCert(l.lbName, ing, client, forceUpdate)
+		certLinks, cErr := l.scs.EnsureSSLCerts(l.lbName, ing, client, forceUpdate)
 		if cErr != nil {
 			// Aggregate errors and return all at the end.
 			cErr = fmt.Errorf("Error ensuring SSL certs: %s", cErr)
 			fmt.Println(cErr)
 			err = multierror.Append(err, cErr)
 		}
-
-		tpLink, tpErr := l.tps.EnsureHTTPSTargetProxy(l.lbName, umLink, certLink, forceUpdate)
+		tpLink, tpErr := l.tps.EnsureHTTPSTargetProxy(l.lbName, umLink, certLinks, forceUpdate)
 		if tpErr != nil {
 			// Aggregate errors and return all at the end.
 			tpErr = fmt.Errorf("Error ensuring HTTPS target proxy: %s", tpErr)
@@ -246,7 +245,7 @@ func (l *Syncer) DeleteLoadBalancer(ing *v1beta1.Ingress, forceDelete bool) erro
 		// Aggregate errors and return all at the end.
 		err = multierror.Append(err, tpErr)
 	}
-	if scErr := l.scs.DeleteSSLCert(); scErr != nil {
+	if scErr := l.scs.DeleteSSLCerts(); scErr != nil {
 		// Aggregate errors and return all at the end.
 		err = multierror.Append(err, scErr)
 	}

--- a/app/kubemci/pkg/gcp/sslcert/fake_sslcertsyncer.go
+++ b/app/kubemci/pkg/gcp/sslcert/fake_sslcertsyncer.go
@@ -45,17 +45,17 @@ var _ SyncerInterface = &fakeSSLCertSyncer{}
 
 // EnsureSSLCert ensures that the required ssl certs exist for the given load balancer.
 // See interface for more details.
-func (f *fakeSSLCertSyncer) EnsureSSLCert(lbName string, ing *v1beta1.Ingress, client kubeclient.Interface, forceUpdate bool) (string, error) {
+func (f *fakeSSLCertSyncer) EnsureSSLCerts(lbName string, ing *v1beta1.Ingress, client kubeclient.Interface, forceUpdate bool) ([]string, error) {
 	f.EnsuredSSLCerts = append(f.EnsuredSSLCerts, fakeSSLCert{
 		LBName:  lbName,
 		Ingress: ing,
 	})
-	return FakeSSLCertSelfLink, nil
+	return []string{FakeSSLCertSelfLink}, nil
 }
 
 // DeleteSSLCert deletes the ssl certs that EnsureSSLCert would have created.
 // See interface for more details.
-func (f *fakeSSLCertSyncer) DeleteSSLCert() error {
+func (f *fakeSSLCertSyncer) DeleteSSLCerts() error {
 	f.EnsuredSSLCerts = nil
 	return nil
 }

--- a/app/kubemci/pkg/gcp/sslcert/interfaces.go
+++ b/app/kubemci/pkg/gcp/sslcert/interfaces.go
@@ -22,10 +22,10 @@ import (
 
 // SyncerInterface is an interface to manage GCP ssl certs.
 type SyncerInterface interface {
-	// EnsureSSLCert ensures that the required ssl cert exists for the given ingress.
-	// Will only change an existing SSL cert if forceUpdate=True.
+	// EnsureSSLCerts ensures that the required ssl cert exists for the given ingress.
+	// Will only change existing SSL certs if forceUpdate=True.
 	// Returns the self link for the ensured ssl cert.
-	EnsureSSLCert(lbName string, ing *v1beta1.Ingress, client kubeclient.Interface, forceUpdate bool) (string, error)
-	// DeleteSSLCert deletes the ssl cert that EnsureSSLCert would have created.
-	DeleteSSLCert() error
+	EnsureSSLCerts(lbName string, ing *v1beta1.Ingress, client kubeclient.Interface, forceUpdate bool) ([]string, error)
+	// DeleteSSLCerts deletes the ssl certs that EnsureSSLCerts would have created.
+	DeleteSSLCerts() error
 }

--- a/app/kubemci/pkg/gcp/targetproxy/fake_targetproxysyncer.go
+++ b/app/kubemci/pkg/gcp/targetproxy/fake_targetproxysyncer.go
@@ -23,7 +23,7 @@ type fakeTargetProxy struct {
 	LBName string
 	UmLink string
 	// Link to the SSL certificate. This is present only for HTTPS target proxies.
-	CertLink string
+	CertLinks []string
 }
 
 // FakeTargetProxySyncer is a fake implementation of SyncerInterface to be used in tests.
@@ -52,11 +52,11 @@ func (f *FakeTargetProxySyncer) EnsureHTTPTargetProxy(lbName, umLink string, for
 
 // EnsureHTTPSTargetProxy ensures that a https target proxy exists for the given load balancer.
 // See interface comments for details.
-func (f *FakeTargetProxySyncer) EnsureHTTPSTargetProxy(lbName, umLink, certLink string, forceUpdate bool) (string, error) {
+func (f *FakeTargetProxySyncer) EnsureHTTPSTargetProxy(lbName, umLink string, certLinks []string, forceUpdate bool) (string, error) {
 	f.EnsuredTargetProxies = append(f.EnsuredTargetProxies, fakeTargetProxy{
-		LBName:   lbName,
-		UmLink:   umLink,
-		CertLink: certLink,
+		LBName:    lbName,
+		UmLink:    umLink,
+		CertLinks: certLinks,
 	})
 	return FakeTargetProxySelfLink, nil
 }

--- a/app/kubemci/pkg/gcp/targetproxy/interfaces.go
+++ b/app/kubemci/pkg/gcp/targetproxy/interfaces.go
@@ -27,7 +27,7 @@ type SyncerInterface interface {
 	// overwrite an existing and different http target proxy if forceUpdate
 	// is true.
 	// Returns the self link for the ensured proxy.
-	EnsureHTTPSTargetProxy(lbName, urlMapLink, certLink string, forceUpdate bool) (string, error)
+	EnsureHTTPSTargetProxy(lbName, urlMapLink string, certLinks []string, forceUpdate bool) (string, error)
 	// DeleteTargetProxies deletes the target proxies that EnsureHTTPTargetProxy
 	// and EnsureHTTPSTargetProxy would have created.
 	DeleteTargetProxies() error


### PR DESCRIPTION
Adds support for multiple pre-shared certificates in Ingress and Load balancer.

This addresses https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/120 for pre-shared ssl certificates, but not for secret ssl certificates; the latter would require updating to a version of the [kubernetes/ingress-gce](https://github.com/kubernetes/ingress-gce) library that returns multiple TLSCerts from `TLSCertsFromSecretsLoader.Load()`.

A known issue is that updates to the pre-shared certificates in the Ingress definition will not propagate to changes to the Load balancer: https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/141. Addressing this would also require updating to a newer version of the [Google Compute API](https://github.com/googleapis/google-api-go-client/tree/master/compute/v1) to leverage `TargetHttpsProxiesService.SetSslCertificates()`.