### PR TITLE
Add oauth authorization via an --access-token flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # kubemci
 
-[![GoReportCard Widget]][GoReportCard] [![Coveralls Widget]][Coveralls] [![GoDoc Widget]][GoDoc] [![Slack Widget]][Slack]
+[![GoReportCard Widget]][goreportcard] [![Coveralls Widget]][coveralls] [![GoDoc Widget]][godoc] [![Slack Widget]][slack]
 
-[GoReportCard Widget]: https://goreportcard.com/badge/github.com/GoogleCloudPlatform/k8s-multicluster-ingress
-[GoReportCard]: https://goreportcard.com/report/github.com/GoogleCloudPlatform/k8s-multicluster-ingress
-[Coveralls Widget]: https://coveralls.io/repos/github/GoogleCloudPlatform/k8s-multicluster-ingress/badge.svg
-[Coveralls]: https://coveralls.io/github/GoogleCloudPlatform/k8s-multicluster-ingress
-[GoDoc Widget]: https://godoc.org/github.com/GoogleCloudPlatform/k8s-multicluster-ingress?status.svg
-[GoDoc]: https://godoc.org/github.com/GoogleCloudPlatform/k8s-multicluster-ingress
-[Slack Widget]: https://s3.eu-central-1.amazonaws.com/ngtuna/join-us-on-slack.png
-[Slack]: http://slack.kubernetes.io#sig-multicluster
+[goreportcard widget]: https://goreportcard.com/badge/github.com/GoogleCloudPlatform/k8s-multicluster-ingress
+[goreportcard]: https://goreportcard.com/report/github.com/GoogleCloudPlatform/k8s-multicluster-ingress
+[coveralls widget]: https://coveralls.io/repos/github/GoogleCloudPlatform/k8s-multicluster-ingress/badge.svg
+[coveralls]: https://coveralls.io/github/GoogleCloudPlatform/k8s-multicluster-ingress
+[godoc widget]: https://godoc.org/github.com/GoogleCloudPlatform/k8s-multicluster-ingress?status.svg
+[godoc]: https://godoc.org/github.com/GoogleCloudPlatform/k8s-multicluster-ingress
+[slack widget]: https://s3.eu-central-1.amazonaws.com/ngtuna/join-us-on-slack.png
+[slack]: http://slack.kubernetes.io#sig-multicluster
 
 kubemci is a tool to configure Kubernetes ingress to load balance traffic across
 multiple Kubernetes clusters.
@@ -24,6 +24,14 @@ You can try out kubemci using the [zone printer example](/examples/zone-printer)
 Follow the instructions as detailed [here](/examples/zone-printer/README.md).
 
 To create an HTTPS ingress, follow the instructions [here](/examples/zone-printer/https.md).
+
+## Authorization
+
+By default, kubemci relies on the discovery of [Application Default Credentials](https://cloud.google.com/docs/authentication/production#finding_credentials_automatically) to authorize access to GCP resources.
+
+As an alternative, kubemci accepts an `--access-token` argument that takes an oauth access token,
+such as one generated for a service account via `gcloud --impersonate-service-account ... auth print-access-token`.
+This method obviates the need to distribute private keys.
 
 ## More information
 
@@ -48,12 +56,12 @@ https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/117
 
 ## Caveats
 
-* Users will be need to specify a unique NodePort for their multicluster services (that should be available across all clusters). This is a pretty onerous requirement, required because health checks need to be the same across all clusters.
+- Users will be need to specify a unique NodePort for their multicluster services (that should be available across all clusters). This is a pretty onerous requirement, required because health checks need to be the same across all clusters.
 
-* This will only work for clusters in the same GCP project. In future, we can integrate with Shared VPC to enable cross project load balancing.
+- This will only work for clusters in the same GCP project. In future, we can integrate with Shared VPC to enable cross project load balancing.
 
-* Load balancing across clusters in the same region will happen in proportion to the number of nodes in each cluster, instead of number of containers.
+- Load balancing across clusters in the same region will happen in proportion to the number of nodes in each cluster, instead of number of containers.
 
-* Since ILBs and ingress share the same instance groups (IGs), there is a race condition where deleting ILBs can cause the IG supposed to be used for multicluster ingress to be deleted. This will be fixed in the next ingress controller forced sync (every 10 mins). The same race condition exists in single cluster ingress as well.
+- Since ILBs and ingress share the same instance groups (IGs), there is a race condition where deleting ILBs can cause the IG supposed to be used for multicluster ingress to be deleted. This will be fixed in the next ingress controller forced sync (every 10 mins). The same race condition exists in single cluster ingress as well.
 
-* Users need to explicitly update all their existing multicluster ingresses (by running `kubemci create ingress`), if they add nodes from a new zone to a cluster. This is required so that the tool can update backend service and add a new instance group to it.
+- Users need to explicitly update all their existing multicluster ingresses (by running `kubemci create ingress`), if they add nodes from a new zone to a cluster. This is required so that the tool can update backend service and add a new instance group to it.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # kubemci
 
-[![GoReportCard Widget]][goreportcard] [![Coveralls Widget]][coveralls] [![GoDoc Widget]][godoc] [![Slack Widget]][slack]
+[![GoReportCard Widget]][GoReportCard] [![Coveralls Widget]][Coveralls] [![GoDoc Widget]][GoDoc] [![Slack Widget]][Slack]
 
-[goreportcard widget]: https://goreportcard.com/badge/github.com/GoogleCloudPlatform/k8s-multicluster-ingress
-[goreportcard]: https://goreportcard.com/report/github.com/GoogleCloudPlatform/k8s-multicluster-ingress
-[coveralls widget]: https://coveralls.io/repos/github/GoogleCloudPlatform/k8s-multicluster-ingress/badge.svg
-[coveralls]: https://coveralls.io/github/GoogleCloudPlatform/k8s-multicluster-ingress
-[godoc widget]: https://godoc.org/github.com/GoogleCloudPlatform/k8s-multicluster-ingress?status.svg
-[godoc]: https://godoc.org/github.com/GoogleCloudPlatform/k8s-multicluster-ingress
-[slack widget]: https://s3.eu-central-1.amazonaws.com/ngtuna/join-us-on-slack.png
-[slack]: http://slack.kubernetes.io#sig-multicluster
+[GoReportCard Widget]: https://goreportcard.com/badge/github.com/GoogleCloudPlatform/k8s-multicluster-ingress
+[GoReportCard]: https://goreportcard.com/report/github.com/GoogleCloudPlatform/k8s-multicluster-ingress
+[Coveralls Widget]: https://coveralls.io/repos/github/GoogleCloudPlatform/k8s-multicluster-ingress/badge.svg
+[Coveralls]: https://coveralls.io/github/GoogleCloudPlatform/k8s-multicluster-ingress
+[GoDoc Widget]: https://godoc.org/github.com/GoogleCloudPlatform/k8s-multicluster-ingress?status.svg
+[GoDoc]: https://godoc.org/github.com/GoogleCloudPlatform/k8s-multicluster-ingress
+[Slack Widget]: https://s3.eu-central-1.amazonaws.com/ngtuna/join-us-on-slack.png
+[Slack]: http://slack.kubernetes.io#sig-multicluster
 
 kubemci is a tool to configure Kubernetes ingress to load balance traffic across
 multiple Kubernetes clusters.
@@ -56,12 +56,12 @@ https://github.com/GoogleCloudPlatform/k8s-multicluster-ingress/issues/117
 
 ## Caveats
 
-- Users will be need to specify a unique NodePort for their multicluster services (that should be available across all clusters). This is a pretty onerous requirement, required because health checks need to be the same across all clusters.
+* Users will be need to specify a unique NodePort for their multicluster services (that should be available across all clusters). This is a pretty onerous requirement, required because health checks need to be the same across all clusters.
 
-- This will only work for clusters in the same GCP project. In future, we can integrate with Shared VPC to enable cross project load balancing.
+* This will only work for clusters in the same GCP project. In future, we can integrate with Shared VPC to enable cross project load balancing.
 
-- Load balancing across clusters in the same region will happen in proportion to the number of nodes in each cluster, instead of number of containers.
+* Load balancing across clusters in the same region will happen in proportion to the number of nodes in each cluster, instead of number of containers.
 
-- Since ILBs and ingress share the same instance groups (IGs), there is a race condition where deleting ILBs can cause the IG supposed to be used for multicluster ingress to be deleted. This will be fixed in the next ingress controller forced sync (every 10 mins). The same race condition exists in single cluster ingress as well.
+* Since ILBs and ingress share the same instance groups (IGs), there is a race condition where deleting ILBs can cause the IG supposed to be used for multicluster ingress to be deleted. This will be fixed in the next ingress controller forced sync (every 10 mins). The same race condition exists in single cluster ingress as well.
 
-- Users need to explicitly update all their existing multicluster ingresses (by running `kubemci create ingress`), if they add nodes from a new zone to a cluster. This is required so that the tool can update backend service and add a new instance group to it.
+* Users need to explicitly update all their existing multicluster ingresses (by running `kubemci create ingress`), if they add nodes from a new zone to a cluster. This is required so that the tool can update backend service and add a new instance group to it.

--- a/app/kubemci/cmd/getstatus.go
+++ b/app/kubemci/cmd/getstatus.go
@@ -42,6 +42,8 @@ type getStatusOptions struct {
 	// Required
 	// TODO(nikhiljindal): This should be optional. Figure it out from gcloud settings.
 	GCPProject string
+	// Access token with which to access gpc resources.
+	AccessToken string
 }
 
 func newCmdGetStatus(out, err io.Writer) *cobra.Command {
@@ -69,6 +71,7 @@ func newCmdGetStatus(out, err io.Writer) *cobra.Command {
 func addGetStatusFlags(cmd *cobra.Command, options *getStatusOptions) error {
 	// TODO(nikhiljindal): Add a short flag "-p" if it seems useful.
 	cmd.Flags().StringVarP(&options.GCPProject, "gcp-project", "", options.GCPProject, "[optional] name of the gcp project. Is fetched using gcloud config get-value project if unset here")
+	cmd.Flags().StringVarP(&options.AccessToken, "access-token", "t", options.AccessToken, "[optional] access token for gcp resources (defaults to GOOGLE_APPLICATION_CREDENTIALS).")
 	// TODO Add a verbose flag that turns on glog logging.
 	return nil
 }
@@ -92,7 +95,7 @@ func validateGetStatusArgs(options *getStatusOptions, args []string) error {
 func runGetStatus(options *getStatusOptions, args []string) error {
 	options.LBName = args[0]
 
-	cloudInterface, err := cloudinterface.NewGCECloudInterface(options.GCPProject)
+	cloudInterface, err := cloudinterface.NewGCECloudInterface(options.GCPProject, options.AccessToken)
 	if err != nil {
 		return fmt.Errorf("error in creating cloud interface: %s", err)
 	}

--- a/app/kubemci/cmd/list.go
+++ b/app/kubemci/cmd/list.go
@@ -38,6 +38,8 @@ type listOptions struct {
 	// Required
 	// TODO(nikhiljindal): This should be optional. Figure it out from gcloud settings.
 	GCPProject string
+	// Access token with which to access gpc resources.
+	AccessToken string
 }
 
 func newCmdList(out, err io.Writer) *cobra.Command {
@@ -63,6 +65,7 @@ func newCmdList(out, err io.Writer) *cobra.Command {
 
 func addListFlags(cmd *cobra.Command, options *listOptions) error {
 	cmd.Flags().StringVarP(&options.GCPProject, "gcp-project", "", options.GCPProject, "[optional] name of the gcp project. Is fetched using 'gcloud config get-value project' if unset here")
+	cmd.Flags().StringVarP(&options.AccessToken, "access-token", "t", options.AccessToken, "[optional] access token for gcp resources (defaults to GOOGLE_APPLICATION_CREDENTIALS).")
 	return nil
 }
 
@@ -84,7 +87,7 @@ func validateListArgs(options *listOptions, args []string) error {
 
 // runList prints a list of all mcis that we've created.
 func runList(options *listOptions, args []string) error {
-	cloudInterface, err := cloudinterface.NewGCECloudInterface(options.GCPProject)
+	cloudInterface, err := cloudinterface.NewGCECloudInterface(options.GCPProject, options.AccessToken)
 	if err != nil {
 		fmt.Println("error creating cloud interface:", err)
 		return fmt.Errorf("error in creating cloud interface: %s", err)

--- a/app/kubemci/pkg/gcp/cloudinterface/interface.go
+++ b/app/kubemci/pkg/gcp/cloudinterface/interface.go
@@ -15,17 +15,18 @@
 package cloudinterface
 
 import (
+	"golang.org/x/oauth2"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 )
 
 // NewGCECloudInterface returns a new GCECloud.
-func NewGCECloudInterface(projectID string) (*gce.GCECloud, error) {
-	config := getCloudConfig(projectID)
+func NewGCECloudInterface(projectID, accessToken string) (*gce.GCECloud, error) {
+	config := getCloudConfig(projectID, accessToken)
 	return gce.CreateGCECloud(&config)
 }
 
-func getCloudConfig(projectID string) gce.CloudConfig {
-	return gce.CloudConfig{
+func getCloudConfig(projectID, accessToken string) gce.CloudConfig {
+	c := gce.CloudConfig{
 		ProjectID: projectID,
 		// TODO(nikhiljindal): Set the following properties.
 		// ApiEndpoint
@@ -33,4 +34,8 @@ func getCloudConfig(projectID string) gce.CloudConfig {
 		// Zone, Region
 		// NetworkName, SubnetworkName
 	}
+	if len(accessToken) > 0 {
+		c.TokenSource = oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken})
+	}
+	return c
 }


### PR DESCRIPTION
Discovery of Application Default Credentials requires private keys to be distributed and discovered via the `GOOGLE_APPLICATION_CREDENTIALS` environment variable. This change allows kubemci to accept an oauth `--access-token` as an alternative.