### PR TITLE
Add datacenters

### DIFF
--- a/examples/zone-printer/src/main.go
+++ b/examples/zone-printer/src/main.go
@@ -155,29 +155,41 @@ var (
 		location string
 		flagURL  string // flag images must be public domain
 	}{
-		"northamerica-northeast1": {
-			location: "Montréal, Canada",
-			flagURL:  "https://upload.wikimedia.org/wikipedia/commons/d/d9/Flag_of_Canada_%28Pantone%29.svg",
+		"asia-east1": {
+			location: "Changhua County, Taiwan",
+			flagURL:  "https://upload.wikimedia.org/wikipedia/commons/7/72/Flag_of_the_Republic_of_China.svg",
 		},
-		"us-central1": {
-			location: "Council Bluffs, Iowa, USA",
-			flagURL:  "https://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+		"asia-northeast1": {
+			location: "Tokyo, Japan",
+			flagURL:  "https://upload.wikimedia.org/wikipedia/en/9/9e/Flag_of_Japan.svg",
 		},
-		"us-west1": {
-			location: "The Dalles, Oregon, USA",
-			flagURL:  "https://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+		"asia-northeast2": {
+			location: "Osaka, Japan",
+			flagURL:  "https://upload.wikimedia.org/wikipedia/en/9/9e/Flag_of_Japan.svg",
 		},
-		"us-east4": {
-			location: "Ashburn, Virginia, USA",
-			flagURL:  "https://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+		"asia-northeast3": {
+			location: "Seoul, South Korea",
+			flagURL:  "https://upload.wikimedia.org/wikipedia/commons/0/09/Flag_of_South_Korea.svg",
 		},
-		"us-east1": {
-			location: "Moncks Corner, South Carolina, USA",
-			flagURL:  "https://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+		"asia-east2": {
+			location: "Hong Kong",
+			flagURL:  "https://upload.wikimedia.org/wikipedia/commons/5/5b/Flag_of_Hong_Kong.svg",
 		},
-		"southamerica-east1": {
-			location: "São Paulo, Brazil",
-			flagURL:  "https://upload.wikimedia.org/wikipedia/en/0/05/Flag_of_Brazil.svg",
+		"asia-south1": {
+			location: "Mumbai, India",
+			flagURL:  "https://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+		},
+		"asia-southeast1": {
+			location: "Jurong West, Singapore",
+			flagURL:  "https://upload.wikimedia.org/wikipedia/commons/4/48/Flag_of_Singapore.svg",
+		},
+		"australia-southeast1": {
+			location: "Sydney, Australia",
+			flagURL:  "https://upload.wikimedia.org/wikipedia/en/b/b9/Flag_of_Australia.svg",
+		},
+		"europe-north1": {
+			location: "Hamina, Finland",
+			flagURL:  "https://upload.wikimedia.org/wikipedia/commons/b/bc/Flag_of_Finland.svg",
 		},
 		"europe-west1": {
 			location: "St. Ghislain, Belgium",
@@ -195,25 +207,45 @@ var (
 			location: "Eemshaven, Netherlands",
 			flagURL:  "https://upload.wikimedia.org/wikipedia/commons/2/20/Flag_of_the_Netherlands.svg",
 		},
-		"asia-south1": {
-			location: "Mumbai, India",
-			flagURL:  "https://upload.wikimedia.org/wikipedia/en/4/41/Flag_of_India.svg",
+		"europe-west6": {
+			location: "Zürich, Switzerland",
+			flagURL:  "https://upload.wikimedia.org/wikipedia/commons/f/f3/Flag_of_Switzerland.svg",
 		},
-		"asia-southeast1": {
-			location: "Jurong West, Singapore",
-			flagURL:  "https://upload.wikimedia.org/wikipedia/commons/4/48/Flag_of_Singapore.svg",
+		"northamerica-northeast1": {
+			location: "Montréal, Canada",
+			flagURL:  "https://upload.wikimedia.org/wikipedia/commons/d/d9/Flag_of_Canada_%28Pantone%29.svg",
 		},
-		"asia-east1": {
-			location: "Changhua County, Taiwan",
-			flagURL:  "https://upload.wikimedia.org/wikipedia/commons/7/72/Flag_of_the_Republic_of_China.svg",
+		"southamerica-east1": {
+			location: "São Paulo, Brazil",
+			flagURL:  "https://upload.wikimedia.org/wikipedia/en/0/05/Flag_of_Brazil.svg",
 		},
-		"asia-northeast1": {
-			location: "Tokyo, Japan",
-			flagURL:  "https://upload.wikimedia.org/wikipedia/en/9/9e/Flag_of_Japan.svg",
+		"us-central1": {
+			location: "Council Bluffs, Iowa, USA",
+			flagURL:  "https://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
 		},
-		"australia-southeast1": {
-			location: "Sydney, Australia",
-			flagURL:  "https://upload.wikimedia.org/wikipedia/en/b/b9/Flag_of_Australia.svg",
+		"us-east1": {
+			location: "Moncks Corner, South Carolina, USA",
+			flagURL:  "https://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+		},
+		"us-east4": {
+			location: "Ashburn, Virginia, USA",
+			flagURL:  "https://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+		},
+		"us-west1": {
+			location: "The Dalles, Oregon, USA",
+			flagURL:  "https://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+		},
+		"us-west2": {
+			location: "Los Angeles, California, USA",
+			flagURL:  "https://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+		},
+		"us-west3": {
+			location: "Salt Lake City, Utah, USA",
+			flagURL:  "https://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
+		},
+		"us-west4": {
+			location: "Las Vegas, Nevada, USA",
+			flagURL:  "https://upload.wikimedia.org/wikipedia/en/a/a4/Flag_of_the_United_States.svg",
 		},
 	}
 )


### PR DESCRIPTION
- Add latest datacenters described in [Regions and Zones](https://cloud.google.com/compute/docs/regions-zones/)
  - asia-east2
  - asia-northeast2
  - asia-northeast3
  - europe-north1
  - europe-west6
  - us-west2
  - us-west3
  - us-west4
- sorted in alphabetical order